### PR TITLE
docs: adapt new default strategy native -> keys

### DIFF
--- a/docs/modules/ROOT/examples/python/write_relationship.py
+++ b/docs/modules/ROOT/examples/python/write_relationship.py
@@ -47,6 +47,8 @@ def nativeStrategy():
         # Create new relationships
         .mode("Append")
         .format("org.neo4j.spark.DataSource")
+        # Use `native` strategy
+        .option("relationship.save.strategy", "native")
         # Assign a type to the relationships
         .option("relationship", "BOUGHT")
         # Create source nodes and assign them a label
@@ -141,8 +143,6 @@ def matchMode():
         .format("org.neo4j.spark.DataSource")
         # Assign a type to the relationships
         .option("relationship", "BOUGHT")
-        # Use `keys` strategy
-        .option("relationship.save.strategy", "keys")
         # Match source nodes with the specified label
         .option("relationship.source.save.mode", "Match")
         .option("relationship.source.labels", ":Customer")
@@ -196,8 +196,6 @@ def overwriteMode():
         .format("org.neo4j.spark.DataSource")
         # Assign a type to the relationships
         .option("relationship", "BOUGHT")
-        # Use `keys` strategy
-        .option("relationship.save.strategy", "keys")
         # Overwrite source nodes and assign them a label
         .option("relationship.source.save.mode", "Overwrite")
         .option("relationship.source.labels", ":Customer")
@@ -251,8 +249,6 @@ def overwriteModeNodeRel():
         .format("org.neo4j.spark.DataSource")
         # Assign a type to the relationships
         .option("relationship", "BOUGHT")
-        # Use `keys` strategy
-        .option("relationship.save.strategy", "keys")
         # Overwrite source nodes and assign them a label
         .option("relationship.source.save.mode", "Overwrite")
         .option("relationship.source.labels", ":Customer")

--- a/docs/modules/ROOT/examples/scala/BasicRelationship.scala
+++ b/docs/modules/ROOT/examples/scala/BasicRelationship.scala
@@ -27,8 +27,6 @@ relDF.write
     .format("org.neo4j.spark.DataSource")
     // Assign a type to the relationships
     .option("relationship", "BOUGHT")
-    // Use `keys` strategy
-    .option("relationship.save.strategy", "keys")
     // Create source nodes and assign them a label
     .option("relationship.source.save.mode", "Append")
     .option("relationship.source.labels", ":Customer")

--- a/docs/modules/ROOT/examples/scala/WriteRelationship.scala
+++ b/docs/modules/ROOT/examples/scala/WriteRelationship.scala
@@ -35,6 +35,8 @@ def nativeStrategy() = {
         // Create new relationships
         .mode(SaveMode.Append)
         .format("org.neo4j.spark.DataSource")
+        // User `native` strategy
+        .option("relationship.save.strategy", "native")
         // Assign a type to the relationships
         .option("relationship", "BOUGHT")
         // Create source nodes and assign them a label
@@ -94,8 +96,6 @@ def matchMode() = {
         .format("org.neo4j.spark.DataSource")
         // Assign a type to the relationships
         .option("relationship", "BOUGHT")
-        // Use `keys` strategy
-        .option("relationship.save.strategy", "keys")
         // Match source nodes with the specified label
         .option("relationship.source.save.mode", "Match")
         .option("relationship.source.labels", ":Customer")
@@ -132,8 +132,6 @@ def overwriteMode() = {
         .format("org.neo4j.spark.DataSource")
         // Assign a type to the relationships
         .option("relationship", "BOUGHT")
-        // Use `keys` strategy
-        .option("relationship.save.strategy", "keys")
         // Overwrite source nodes and assign them a label
         .option("relationship.source.save.mode", "Overwrite")
         .option("relationship.source.labels", ":Customer")
@@ -170,8 +168,6 @@ def overwriteModeNodeRel() = {
         .format("org.neo4j.spark.DataSource")
         // Assign a type to the relationships
         .option("relationship", "BOUGHT")
-        // Use `keys` strategy
-        .option("relationship.save.strategy", "keys")
         // Overwrite source nodes and assign them a label
         .option("relationship.source.save.mode", "Overwrite")
         .option("relationship.source.labels", ":Customer")

--- a/docs/modules/ROOT/pages/databricks.adoc
+++ b/docs/modules/ROOT/pages/databricks.adoc
@@ -175,8 +175,6 @@ relDF = spark.read.table("customers_products_example")
     .format("org.neo4j.spark.DataSource")
     # Assign a type to the relationships
     .option("relationship", "BOUGHT")
-    # Use `keys` strategy
-    .option("relationship.save.strategy", "keys")
     # Create source nodes and assign them a label
     .option("relationship.source.save.mode", "Append")
     .option("relationship.source.labels", ":Customer")

--- a/docs/modules/ROOT/pages/write/options.adoc
+++ b/docs/modules/ROOT/pages/write/options.adoc
@@ -69,7 +69,7 @@ Set to `0` to disable.
 |No
 
 |`relationship.properties`
-|Used only if `relationship.save.strategy` is `keys`.
+|Used only if `relationship.save.strategy` is `keys` (default).
 Map used as keys for specifying the *relationship* properties.
 When set, only the relationships included in the map are set as relationship properties.
 When the option is not set, all unmapped fields are set as relationship properties.
@@ -78,7 +78,7 @@ When the option is not set, all unmapped fields are set as relationship properti
 
 |`relationship.save.strategy`
 |xref:write/relationship.adoc#strategies[Save strategy] to be used
-|`native`
+|`keys`
 |Yes
 
 |`relationship.source.labels`
@@ -102,7 +102,7 @@ When the option is not set, all unmapped fields are set as relationship properti
 |No
 
 |`relationship.source.node.properties`
-|Map used as keys for specifying the *source* properties. Only used if `relationship.save.strategy` is `keys`
+|Map used as keys for specifying the *source* properties. Only used if `relationship.save.strategy` is `keys` (default)
 |_(empty)_
 |No
 
@@ -127,7 +127,7 @@ When the option is not set, all unmapped fields are set as relationship properti
 |No
 
 |`relationship.target.node.properties`
-|Map used as keys for specifying the *target* properties. Only used if `relationship.save.strategy` is `keys`
+|Map used as keys for specifying the *target* properties. Only used if `relationship.save.strategy` is `keys` (default)
 |_(empty)_
 |No
 

--- a/docs/modules/ROOT/pages/write/relationship.adoc
+++ b/docs/modules/ROOT/pages/write/relationship.adoc
@@ -20,7 +20,7 @@ The rest of the query is built depending on a number of data source options.
 |
 * `native` requires the DataFrame to use a specific schema.
 * `keys` is more flexible.
-|`native`
+|`keys`
 
 |`relationship.source.save.mode`
 
@@ -61,14 +61,14 @@ If `key` and `value` have the same value (for example `"name:name"`), you can om
 and
 
 `relationship.target.node.properties`
-|When the <<strategies, save strategy>> is `keys`, define which DataFrame columns to write as source/target node properties.
+|When the <<strategies, save strategy>> is `keys` (default), define which DataFrame columns to write as source/target node properties.
 |Comma-separated list of `key:value` pairs.
 
 If `key` and `value` have the same value (for example `"name:name"`), you can omit one.
 |_(empty)_
 
 |`relationship.properties`
-|When the <<strategies, save strategy>> is `keys`, defines which DataFrame columns to write as relationship properties.
+|When the <<strategies, save strategy>> is `keys` (default), defines which DataFrame columns to write as relationship properties.
 |Comma-separated list of `key:value` pairs.
 
 If `key` and `value` have the same value (for example `"name:name"`), you can omit one.


### PR DESCRIPTION
In spark connector 6.0.0 we changed the default save strategy for
relationships from `native` to `keys`. This was not properly documented
in our 6.0.0 documentation efforts.

This PR fills this gap by properly documenting `keys` as the default
value. And updates existing examples by adding now-missing `native`
options to examples that assumed this default. Also removes `keys`
options to test cases that previously could not assume this default.

We have this one example that demonstrates how to use `keys` strategy
itself. For that example, I kept the option to be explicit.