### PR TITLE
docs: add db.transaction.metadata in changelog

### DIFF
--- a/docs/modules/ROOT/pages/changelog.adoc
+++ b/docs/modules/ROOT/pages/changelog.adoc
@@ -54,6 +54,13 @@ Add indexed `script.N` options
 a| Default `relationship.save.strategy` is now `KEYS`
 | Changed `relationship.save.strategy` default value from `NATIVE` to `KEYS`.
 
+a|
+label:new[]
+label:feature[]
+
+Add custom transaction metadata
+| It is now possible for spark clients to set custom Neo4j Driver transaction metadata using option `db.transaction.metadata`.
+
 |===
 
 [NOTE]

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -284,6 +284,10 @@ Available values are:
 |_(Neo4j Driver default)_
 |No
 
+|`db.transaction.metadata`
+|Tag custom transaction metadata to the driver, works on read and write, details below
+|No
+
 4+|*Session options*
 
 |`database`

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -286,6 +286,7 @@ Available values are:
 
 |`db.transaction.metadata`
 |Tag custom transaction metadata to the driver, works on read and write, details below
+|_(empty)_
 |No
 
 4+|*Session options*


### PR DESCRIPTION
Small oversight in previous 6.0.0 changelog PR. This feature is new and
already live. It was introduced in 6.0.0-RC01.