### PR TITLE
docs: adding new options to write/read parts of docs

### DIFF
--- a/docs/modules/ROOT/pages/read/options.adoc
+++ b/docs/modules/ROOT/pages/read/options.adoc
@@ -117,6 +117,36 @@ every single node property as column prefixed by `source` or `target`
 |_(empty)_
 |Yes
 
+4+|*Cypher options* [role=label--new-6.0]
+
+|`cypher.version`
+|Set a custom Cypher language version to a custom value.
+Expected value is the version number itself, e.g. `5` or `25`
+|5
+|No
+
+|`cypher.tuning.*`
+|Set any cypher query tuning parameter with this prefix.
+See details on how to properly use this feature link:{neo4j-docs-base-uri}/spark/current/performance/cypher-tuning[here]
+|_(emtpy)_
+|No
+
+4+|*Optimization options*
+
+|`script`
+|Apply a custom Cypher query which will run once before any write operations.
+Use this capability to apply custom optimizations e.g. custom index/contstraint queries.
+Can not be used with `script.N`, use either or.
+|_(empty)_
+|No
+
+|`script.N`
+|Similar to `script`, replace `N` with any positive integer, put as many as you like.
+The scripts are executed in succession and in numbered order.
+Can not be used with plain `script`, use either or.
+|_(empty)_
+|No
+
 |===
 
 ^*^ Just one of the options can be specified at the time.

--- a/docs/modules/ROOT/pages/read/options.adoc
+++ b/docs/modules/ROOT/pages/read/options.adoc
@@ -135,15 +135,15 @@ See more details on how to properly use this feature on link:{neo4j-docs-base-ur
 
 |`script`
 |Apply a custom Cypher query which will run once before any write operations.
-Use this capability to apply custom optimizations e.g. custom index/contstraint queries.
-Can not be used with `script.N`, use either or.
+Use this option to apply optimizations such as the use of a  custom index and constraint queries.
+Can not be used together with the numbered `script.N` option.
 |_(empty)_
 |No
 
 |`script.N`
 |Similar to `script`, replace `N` with any positive integer, put as many as you like.
 The scripts are executed in succession and in numbered order.
-Can not be used with plain `script`, use either or.
+Can not be used together with the unnumbered `script` option.
 |_(empty)_
 |No
 

--- a/docs/modules/ROOT/pages/read/options.adoc
+++ b/docs/modules/ROOT/pages/read/options.adoc
@@ -127,7 +127,7 @@ The expected value is the version number itself, for example `5` or `25`.
 
 |`cypher.tuning.*`
 |Set any cypher query tuning parameter with this prefix.
-See details on how to properly use this feature link:{neo4j-docs-base-uri}/spark/current/performance/cypher-tuning[here]
+See more details on how to properly use this feature on link:{neo4j-docs-base-uri}/spark/current/performance/cypher-tuning[].
 |_(emtpy)_
 |No
 

--- a/docs/modules/ROOT/pages/read/options.adoc
+++ b/docs/modules/ROOT/pages/read/options.adoc
@@ -121,7 +121,7 @@ every single node property as column prefixed by `source` or `target`
 
 |`cypher.version`
 |Set a custom Cypher language version to a custom value.
-Expected value is the version number itself, e.g. `5` or `25`
+The expected value is the version number itself, for example `5` or `25`.
 |5
 |No
 

--- a/docs/modules/ROOT/pages/write/options.adoc
+++ b/docs/modules/ROOT/pages/write/options.adoc
@@ -29,13 +29,6 @@ See xref:write/transactions.adoc#retries[].
 |0
 |No
 
-|`index.await.timeout`
-|Adjust the maximum timeout to wait for index generation.
-Before writing, the `db.awaitIndexes` Cypher procedure will be called with the timeout specified in whole seconds.
-Set to `0` to disable.
-|300
-|No
-
 |`type.conversion`
 |Data conversion logic. When set to `legacy`, timestamps, intervals and byte arrays are processed the same way as they were before 5.4.0. See xref:../types.adoc[] for more information.
 |`default`
@@ -127,6 +120,44 @@ When the option is not set, all unmapped fields are set as relationship properti
 |`relationship.target.node.properties`
 |Map used as keys for specifying the *target* properties. Only used if `relationship.save.strategy` is `keys` (default)
 |_(empty)_
+|No
+
+4+|*Cypher options* [role=label--new-6.0]
+
+|`cypher.version`
+|Set a custom Cypher language version to a custom value.
+Expected value is the version number itself, e.g. `5` or `25`
+|5
+|No
+
+|`cypher.tuning.*`
+|Set any cypher query tuning parameter with this prefix.
+See details on how to properly use this feature link:{neo4j-docs-base-uri}/spark/current/performance/cypher-tuning[here]
+|_(emtpy)_
+|No
+
+4+|*Optimization options*
+
+|`script`
+|Apply a custom Cypher query which will run once before any write operations.
+Use this capability to apply custom optimizations e.g. custom index/contstraint queries.
+Can not be used with `script.N`, use either or.
+|_(empty)_
+|No
+
+|`script.N`
+|Similar to `script`, replace `N` with any positive integer, put as many as you like.
+The scripts are executed in succession and in numbered order.
+Can not be used with plain `script`, use either or.
+|_(empty)_
+|No
+
+|`index.await.timeout`
+|Adjust the maximum timeout to wait for index generation
+Before writing, the `db.awaitIndexes` Cypher procedure will be called with the timeout specified in whole seconds.
+Set to `0` to disable.
+The await happens after any `script` query and before any write operations
+|300
 |No
 
 |===


### PR DESCRIPTION
Trying to make these pages exhaustive and list all possible options.
With that effort, we should add things that are missing.

This PR adds `script`, `script.N`, `cypher*` and moves `index.await` to
the new optimization section.

Indeed, `index.await` is not supported for reads.