### PR TITLE
docs: cover when streaming can cause data loss

### DIFF
--- a/docs/modules/ROOT/pages/streaming.adoc
+++ b/docs/modules/ROOT/pages/streaming.adoc
@@ -152,8 +152,8 @@ The `streaming.property.name` option sets the name of the node or relationship p
 [WARNING]
 ====
 If the values of your streaming property are not unique, you might lose data.
-Structured streaming reads keep track of the progress using the value of the streaming property, which must increase for each subsequent read.
-If this value is already present in a previously written record, the new data will not be read.
+Structured streaming reads keep track of the progress using the value of the streaming property, which must increase for each subsequent read to keep order.
+If you write a new record during streaming whose streaming property value is less than the current stream's checkpoint, that record will not bea read.
 ====
 
 Although the Neo4j `timestamp()` function might seem a good choice to create a streaming property, its millisecond resolution may not be enough to guarantee uniqueness in a write-heavy scenario.

--- a/docs/modules/ROOT/pages/streaming.adoc
+++ b/docs/modules/ROOT/pages/streaming.adoc
@@ -143,20 +143,26 @@ spark \
 
 === Streaming property name
 
-For the streaming to work, you need each record to have a property of type `timestamp`
-to leverage when reading new data from Neo4j to be sent to the stream.
-
-Behind the scenes the connector is building a query with a `WHERE` clause that checks for the
-records that have this `[timestampProperty]` between a range of timestamps computed from checkpoint data
-and latest offset available in the database.
-
-So it's required that each node has the timestamp property of a Neo4j type (Long),
-and it *must* be not `null`.
-
-[NOTE]
-A property of type string like "2021-08-11" does not work. It needs to be a Long of Neo4j type.
-
+For the streaming reads, you need each record to have a "streaming property" to leverage when reading new data from Neo4j to be sent to the stream.
+The name of your streaming property must be passed along using the required option `streaming.property.name`.
 The property name can be anything, just remember to set the `streaming.property.name` accordingly.
+
+Behind the scenes the connector is building a query with a `WHERE` clause that checks for the records' streaming property that falls between a range of values computed from checkpoint data and latest offset available in the database.
+
+Because of how we construct this `WHERE` clause, it is _required_ to use the `Integer` type for the property (equivalent to Java/Scala's Long).
+It must not be `null`.
+We recommend that you use time-ordered sequence of numbers that are uniquely identifying (e.g. an unique incrementing ID).
+
+[WARNING]
+====
+If the values of your streaming property are not unique, you might lose data.
+Structured streaming reads keep track of progress using the highest property seen, then move on to a value strictly greater than that next time.
+If you write a record (mid-streaming) that has a streaming property which is a duplicate of an already read record, this data will not be streamed/read.
+====
+
+Using Neo4j built-in function `timestamp()` as value for these properties is a natural instinct.
+But be warned, if you have records with non-unique timestamps you might have duplicated timestamps in your data.
+Of course you can still use e.g. a `timestamp()` value if your domain can guarantee that this is unique or the above warning is not of concern.
 
 === _Streaming from_ option
 

--- a/docs/modules/ROOT/pages/streaming.adoc
+++ b/docs/modules/ROOT/pages/streaming.adoc
@@ -162,7 +162,10 @@ If you write a record (mid-streaming) that has a streaming property which is a d
 
 Using Neo4j built-in function `timestamp()` as value for these properties is a natural instinct.
 But be warned, if you have records with non-unique timestamps you might have duplicated timestamps in your data.
-Of course you can still use e.g. a `timestamp()` value if your domain can guarantee that this is unique or the above warning is not of concern.
+Imagine you are reading a stream from a Neo4j database under a heavy write scenario over multiple transactions.
+Every timestamp value of writes that happens within the same millisecond will have non-unique timestamp, and is prone to the above warning.
+A streaming read might reach Neo4j in-between two write transactions within the same millisecond.
+The later written records will then never be read.
 
 === _Streaming from_ option
 

--- a/docs/modules/ROOT/pages/streaming.adoc
+++ b/docs/modules/ROOT/pages/streaming.adoc
@@ -153,7 +153,7 @@ The `streaming.property.name` option sets the name of the node or relationship p
 ====
 If the values of your streaming property are not unique, you might lose data.
 Structured streaming reads keep track of the progress using the value of the streaming property, which must increase for each subsequent read to keep order.
-If you write a new record during streaming whose streaming property value is less than the current stream's checkpoint, that record will not bea read.
+If you write a new record during streaming whose streaming property value is less than the current stream's checkpoint, that record will not be read.
 ====
 
 Although the Neo4j `timestamp()` function might seem a good choice to create a streaming property, its millisecond resolution may not be enough to guarantee uniqueness in a write-heavy scenario.

--- a/docs/modules/ROOT/pages/streaming.adoc
+++ b/docs/modules/ROOT/pages/streaming.adoc
@@ -141,31 +141,23 @@ spark \
   .show()
 ----
 
-=== Streaming property name
+=== Streaming property
 
-For the streaming reads, you need each record to have a "streaming property" to leverage when reading new data from Neo4j to be sent to the stream.
-The name of your streaming property must be passed along using the required option `streaming.property.name`.
-The property name can be anything, just remember to set the `streaming.property.name` accordingly.
+When reading from Neo4j, each record must include a unique increasing `Integer` value (a _streaming property_).
 
-Behind the scenes the connector is building a query with a `WHERE` clause that checks for the records' streaming property that falls between a range of values computed from checkpoint data and latest offset available in the database.
+The connector uses the value of the streaming property to filter records between the checkpoint and the latest offset stored in the database.
 
-Because of how we construct this `WHERE` clause, it is _required_ to use the `Integer` type for the property (equivalent to Java/Scala's Long).
-It must not be `null`.
-We recommend that you use time-ordered sequence of numbers that are uniquely identifying (e.g. an unique incrementing ID).
+The `streaming.property.name` option sets the name of the node or relationship property to use.
 
 [WARNING]
 ====
 If the values of your streaming property are not unique, you might lose data.
-Structured streaming reads keep track of progress using the highest property seen, then move on to a value strictly greater than that next time.
-If you write a record (mid-streaming) that has a streaming property which is a duplicate of an already read record, this data will not be streamed/read.
+Structured streaming reads keep track of the progress using the value of the streaming property, which must increase for each subsequent read.
+If this value is already present in a previously written record, the new data will not be read.
 ====
 
-Using Neo4j built-in function `timestamp()` as value for these properties is a natural instinct.
-But be warned, if you have records with non-unique timestamps you might have duplicated timestamps in your data.
-Imagine you are reading a stream from a Neo4j database under a heavy write scenario over multiple transactions.
-Every timestamp value of writes that happens within the same millisecond will have non-unique timestamp, and is prone to the above warning.
-A streaming read might reach Neo4j in-between two write transactions within the same millisecond.
-The later written records will then never be read.
+Although the Neo4j `timestamp()` function might seem a good choice to create a streaming property, its millisecond resolution may not be enough to guarantee uniqueness in a write-heavy scenario.
+If several transactions happen within the same millisecond, the connector will only read one.
 
 === _Streaming from_ option
 

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -350,9 +350,9 @@
       }
     },
     "node_modules/@neo4j-antora/xref-hash-validator": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@neo4j-antora/xref-hash-validator/-/xref-hash-validator-0.1.5.tgz",
-      "integrity": "sha512-trPqvVjP4/lRnind1sj85hP4Z7m72oVkGlBPTNc5hBcinZL+ZFN5qp9z5VRBM/jpr6e1TdKZqetkh3IKsg3lww==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@neo4j-antora/xref-hash-validator/-/xref-hash-validator-0.1.7.tgz",
+      "integrity": "sha512-tdopfVIfHHUVxYg1CqXPtmZts8bZBWYeeDKoJ5enABY0AOQDf4XhvhuW8LxjvuoB+rpare71W9x0H5vFv4bSbg==",
       "license": "MIT",
       "dependencies": {
         "node-html-parser": "7.1.0"
@@ -647,9 +647,9 @@
       }
     },
     "node_modules/body-parser/node_modules/content-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
-      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -667,16 +667,16 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -1831,13 +1831,17 @@
       }
     },
     "node_modules/media-typer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/merge-descriptors": {
@@ -1921,13 +1925,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -1971,13 +1975,34 @@
       }
     },
     "node_modules/negotiator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.1.0.tgz",
+      "integrity": "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/negotiator/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/neo-async": {
@@ -2125,9 +2150,9 @@
       "license": "MIT"
     },
     "node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -2988,9 +3013,9 @@
       }
     },
     "node_modules/type-is/node_modules/content-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
-      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
In a recent audit we found that actually, if you put something trivial
as your streaming property for Spark structured stream reading, you
might end up with data loss.

Because if you write non-unique but time ordered property values, you
might miss out on data being written to Neo4j while you are mid-stream
reading.

This PR aims to improve the docs to warn about this race condition and
makes the requirements for a good property clearer to understand.