### PR TITLE
fix: handle alwaysTrue and alwaysFalse

### DIFF
--- a/common/src/main/scala/org/neo4j/spark/util/Neo4jUtil.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Neo4jUtil.scala
@@ -198,10 +198,13 @@ object Neo4jUtil {
       case contains: StringContains =>
         getCorrectProperty(container, attributeAlias.getOrElse(contains.attribute))
           .contains(valueToCypherExpression(contains.attribute, contains.value))
-      case notNull: IsNotNull   => getCorrectProperty(container, attributeAlias.getOrElse(notNull.attribute)).isNotNull
-      case isNull: IsNull       => getCorrectProperty(container, attributeAlias.getOrElse(isNull.attribute)).isNull
-      case not: Not             => mapSparkFiltersToCypher(not.child, container, attributeAlias).not()
-      case filter @ (_: Filter) => throw new IllegalArgumentException(s"Filter of type `$filter` is not supported.")
+      case notNull: IsNotNull => getCorrectProperty(container, attributeAlias.getOrElse(notNull.attribute)).isNotNull
+      case isNull: IsNull     => getCorrectProperty(container, attributeAlias.getOrElse(isNull.attribute)).isNull
+      case not: Not           => mapSparkFiltersToCypher(not.child, container, attributeAlias).not()
+      case _: AlwaysTrue      => Conditions.noCondition()
+      case _: AlwaysFalse     => Cypher.literalFalse().asCondition()
+      case unsupported =>
+        throw new IllegalArgumentException(s"Filter of type `${unsupported.getClass.getName}` is not supported.")
     }
   }
 

--- a/common/src/main/scala/org/neo4j/spark/util/Neo4jUtil.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Neo4jUtil.scala
@@ -201,7 +201,7 @@ object Neo4jUtil {
       case notNull: IsNotNull => getCorrectProperty(container, attributeAlias.getOrElse(notNull.attribute)).isNotNull
       case isNull: IsNull     => getCorrectProperty(container, attributeAlias.getOrElse(isNull.attribute)).isNull
       case not: Not           => mapSparkFiltersToCypher(not.child, container, attributeAlias).not()
-      case _: AlwaysTrue      => Conditions.noCondition()
+      case _: AlwaysTrue      => Cypher.literalTrue().asCondition()
       case _: AlwaysFalse     => Cypher.literalFalse().asCondition()
       case unsupported =>
         throw new IllegalArgumentException(s"Filter of type `${unsupported.getClass.getName}` is not supported.")

--- a/package.json
+++ b/package.json
@@ -13,5 +13,5 @@
   "dependencies": {
     "spark": "link:"
   },
-  "packageManager": "pnpm@11.20.0+sha512.9a6f330a95b66446ea088faf1521405a8a01f07fde7124cc9958dfed52d4bb436737e65b08f85f37b46fcba375092558ac51262b816844b22f63406ed166bfee"
+  "packageManager": "pnpm@11.24.0"
 }


### PR DESCRIPTION
Neo4jImplicits are capable of creating `AwlaysTrue` and `AlwaysFalse`
filters. However Neo4jUtil considered this as unsupported filter types.

We should be able to safely map `AlwaysTrue` literal true and
`AlwaysFalse` to literal false.