### PR TITLE
fix: handle alwaysTrue and alwaysFalse

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,5 +10,8 @@
   "scripts": {
     "prepare": "husky"
   },
-  "packageManager": "pnpm@11.20.0+sha512.9a6f330a95b66446ea088faf1521405a8a01f07fde7124cc9958dfed52d4bb436737e65b08f85f37b46fcba375092558ac51262b816844b22f63406ed166bfee"
+  "dependencies": {
+    "spark": "link:"
+  },
+  "packageManager": "pnpm@11.24.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,10 @@ overrides:
 importers:
 
   .:
+    dependencies:
+      spark:
+        specifier: 'link:'
+        version: 'link:'
     devDependencies:
       '@commitlint/cli':
         specifier: ^21.2.1

--- a/src/main/scala/org/neo4j/spark/util/Neo4jUtil.scala
+++ b/src/main/scala/org/neo4j/spark/util/Neo4jUtil.scala
@@ -198,10 +198,13 @@ object Neo4jUtil {
       case contains: StringContains =>
         getCorrectProperty(container, attributeAlias.getOrElse(contains.attribute))
           .contains(valueToCypherExpression(contains.attribute, contains.value))
-      case notNull: IsNotNull   => getCorrectProperty(container, attributeAlias.getOrElse(notNull.attribute)).isNotNull
-      case isNull: IsNull       => getCorrectProperty(container, attributeAlias.getOrElse(isNull.attribute)).isNull
-      case not: Not             => mapSparkFiltersToCypher(not.child, container, attributeAlias).not()
-      case filter @ (_: Filter) => throw new IllegalArgumentException(s"Filter of type `$filter` is not supported.")
+      case notNull: IsNotNull => getCorrectProperty(container, attributeAlias.getOrElse(notNull.attribute)).isNotNull
+      case isNull: IsNull     => getCorrectProperty(container, attributeAlias.getOrElse(isNull.attribute)).isNull
+      case not: Not           => mapSparkFiltersToCypher(not.child, container, attributeAlias).not()
+      case _: AlwaysTrue      => Cypher.literalTrue().asCondition()
+      case _: AlwaysFalse     => Cypher.literalFalse().asCondition()
+      case unsupported =>
+        throw new IllegalArgumentException(s"Filter of type `${unsupported.getClass.getName}` is not supported.")
     }
   }
 


### PR DESCRIPTION
Neo4jImplicits are capable of creating `AwlaysTrue` and `AlwaysFalse`
filters. However Neo4jUtil considered this as unsupported filter types.

We should be able to safely map `AlwaysTrue` to literal true and
`AlwaysFalse` to literal false.

Cherry-pick of ea2ec6a4a70dd40b5c26531882ec47d431cfb29c