### PR TITLE
fix: remove NPE in lastestOffset calculation

### DIFF
--- a/spark-3/src/main/scala/org/neo4j/spark/streaming/Neo4jMicroBatchReader.scala
+++ b/spark-3/src/main/scala/org/neo4j/spark/streaming/Neo4jMicroBatchReader.scala
@@ -93,10 +93,16 @@ class Neo4jMicroBatchReader(
           try {
             schemaService.lastOffset()
           } catch {
-            case _: Throwable => null
+            case e: Throwable =>
+              logWarning(
+                "Could not read the latest streaming offset for property " + neo4jOptions.streamingOptions.propertyName,
+                e
+              )
+              Option.empty[Long]
           }
       }
     )
+
     offsetValue.map(value => Neo4jOffset(value)).orNull
   }
 


### PR DESCRIPTION
We accidently silence an exception thrown and then reutrn `null` only
to reach a NPE right after. This PR aims to log the original exception,
then avoid the NPE.