### PR TITLE
fix: replace quote function with Cypher DSL sanitizer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,11 @@
             <version>${cypherdsl.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.neo4j</groupId>
+            <artifactId>neo4j-cypher-dsl-schema-name-support</artifactId>
+            <version>${cypherdsl.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.neo4j.connectors</groupId>
             <artifactId>commons-authn-spi</artifactId>
             <version>${connectors-commons.version}</version>

--- a/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
+++ b/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
@@ -319,7 +319,7 @@ class Neo4jQueryReadStrategy(
 
         if (entity != null && splatColumn.length == 1) {
           entity match {
-            case n: Node         => n.as(entityName.quote())
+            case n: Node         => n.as(entityName.sanitizeSchemaName())
             case r: Relationship => r.getRequiredSymbolicName
           }
         } else {

--- a/src/main/scala/org/neo4j/spark/service/SchemaService.scala
+++ b/src/main/scala/org/neo4j/spark/service/SchemaService.scala
@@ -109,7 +109,7 @@ class SchemaService(
           s"""${fullPreamble(
               neo4j,
               options
-            )}MATCH (${Neo4jUtil.NODE_ALIAS}:${labels.map(_.quote()).mkString(":")})
+            )}MATCH (${Neo4jUtil.NODE_ALIAS}:${labels.map(_.sanitizeSchemaName()).mkString(":")})
              |RETURN ${Neo4jUtil.NODE_ALIAS}
              |ORDER BY rand()
              |LIMIT ${options.schemaMetadata.flattenLimit}
@@ -266,10 +266,10 @@ class SchemaService(
               neo4j,
               options
             )}MATCH (${Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS}:${options.relationshipMetadata.source.labels.map(
-              _.quote()
+              _.sanitizeSchemaName()
             ).mkString(":")})
              |MATCH (${Neo4jUtil.RELATIONSHIP_TARGET_ALIAS}:${options.relationshipMetadata.target.labels.map(
-              _.quote()
+              _.sanitizeSchemaName()
             ).mkString(":")})
              |MATCH (${Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS})-[${Neo4jUtil.RELATIONSHIP_ALIAS}:${options.relationshipMetadata.relationshipType}]->(${Neo4jUtil.RELATIONSHIP_TARGET_ALIAS})
              |RETURN ${Neo4jUtil.RELATIONSHIP_ALIAS}
@@ -333,7 +333,9 @@ class SchemaService(
       columns.map(StructField(_, DataTypes.StringType))
     } else {
       try {
-        columns.map(column => structFields.find(_.name.quote() == column.quote()).orNull).filter(_ != null)
+        columns.map(column =>
+          structFields.find(_.name.sanitizeSchemaName() == column.sanitizeSchemaName()).orNull
+        ).filter(_ != null)
       } catch {
         case _: Throwable => structFields.toArray
       }
@@ -439,7 +441,7 @@ class SchemaService(
   def countForNodeWithQuery(filters: Array[Filter]): Long = {
     val query = if (filters.isEmpty) {
       options.nodeMetadata.labels
-        .map(_.quote())
+        .map(_.sanitizeSchemaName())
         .map(label =>
           s"""
              |MATCH (:$label)
@@ -465,16 +467,16 @@ class SchemaService(
   def countForRelationshipWithQuery(filters: Array[Filter]): Long = {
     val query = if (filters.isEmpty) {
       val sourceQueries = options.relationshipMetadata.source.labels
-        .map(_.quote())
+        .map(_.sanitizeSchemaName())
         .map(label =>
-          s"""MATCH (:$label)-[${Neo4jUtil.RELATIONSHIP_ALIAS}:${options.relationshipMetadata.relationshipType.quote()}]->()
+          s"""MATCH (:$label)-[${Neo4jUtil.RELATIONSHIP_ALIAS}:${options.relationshipMetadata.relationshipType.sanitizeSchemaName()}]->()
              |RETURN count(${Neo4jUtil.RELATIONSHIP_ALIAS}) AS count
              |""".stripMargin
         )
       val targetQueries = options.relationshipMetadata.target.labels
-        .map(_.quote())
+        .map(_.sanitizeSchemaName())
         .map(label =>
-          s"""MATCH ()-[${Neo4jUtil.RELATIONSHIP_ALIAS}:${options.relationshipMetadata.relationshipType.quote()}]->(:$label)
+          s"""MATCH ()-[${Neo4jUtil.RELATIONSHIP_ALIAS}:${options.relationshipMetadata.relationshipType.sanitizeSchemaName()}]->(:$label)
              |RETURN count(${Neo4jUtil.RELATIONSHIP_ALIAS}) AS count
              |""".stripMargin
         )
@@ -704,8 +706,8 @@ class SchemaService(
     }
     val dashSeparatedProps = keys.values.mkString("-")
     val constraintName =
-      s"spark_${entityType}_${constraintType.replace(s"$entityType ", "")}-CONSTRAINT_${entityIdentifier}_$dashSeparatedProps".quote()
-    val props = keys.values.map(_.quote()).map("e." + _).mkString(", ")
+      s"spark_${entityType}_${constraintType.replace(s"$entityType ", "")}-CONSTRAINT_${entityIdentifier}_$dashSeparatedProps".sanitizeSchemaName()
+    val props = keys.values.map(_.sanitizeSchemaName()).map("e." + _).mkString(", ")
     val asciiRepresentation: String = createCypherPattern(entityType, entityIdentifier)
     session.executeWriteWithoutResult(
       tx => {
@@ -719,8 +721,8 @@ class SchemaService(
 
   private def createCypherPattern(entityType: String, entityIdentifier: String) = {
     val asciiRepresentation = entityType match {
-      case "NODE"         => s"(e:${entityIdentifier.quote()})"
-      case "RELATIONSHIP" => s"()-[e:${entityIdentifier.quote()}]->()"
+      case "NODE"         => s"(e:${entityIdentifier.sanitizeSchemaName()})"
+      case "RELATIONSHIP" => s"()-[e:${entityIdentifier.sanitizeSchemaName()}]->()"
       case _              => throw new IllegalArgumentException(s"$entityType not supported")
     }
     asciiRepresentation
@@ -744,18 +746,19 @@ class SchemaService(
           })
           .foreach(t => {
             val prop = t._1
-            val propQuoted = prop.quote()
+            val propQuoted = prop.sanitizeSchemaName()
             val cypherType = t._2
             val isNullable = t._3
             if (constraints.contains(SchemaConstraintsOptimizationType.TYPE)) {
-              val typeConstraintName = s"spark_$entityType-TYPE-CONSTRAINT-$entityIdentifier-$prop".quote()
+              val typeConstraintName = s"spark_$entityType-TYPE-CONSTRAINT-$entityIdentifier-$prop".sanitizeSchemaName()
               tx.run(
                 s"CREATE CONSTRAINT $typeConstraintName IF NOT EXISTS FOR $asciiRepresentation REQUIRE e.$propQuoted IS :: $cypherType"
               ).consume()
             }
             if (constraints.contains(SchemaConstraintsOptimizationType.EXISTS)) {
               if (!isNullable) {
-                val notNullConstraintName = s"spark_$entityType-NOT_NULL-CONSTRAINT-$entityIdentifier-$prop".quote()
+                val notNullConstraintName =
+                  s"spark_$entityType-NOT_NULL-CONSTRAINT-$entityIdentifier-$prop".sanitizeSchemaName()
                 tx.run(
                   s"CREATE CONSTRAINT $notNullConstraintName IF NOT EXISTS FOR $asciiRepresentation REQUIRE e.$propQuoted IS NOT NULL"
                 ).consume()
@@ -935,9 +938,9 @@ class SchemaService(
   }
 
   private def lastOffsetForRelationship(): Option[Long] = {
-    val sourceLabel = options.relationshipMetadata.source.labels.head.quote()
-    val targetLabel = options.relationshipMetadata.target.labels.head.quote()
-    val relType = options.relationshipMetadata.relationshipType.quote()
+    val sourceLabel = options.relationshipMetadata.source.labels.head.sanitizeSchemaName()
+    val targetLabel = options.relationshipMetadata.target.labels.head.sanitizeSchemaName()
+    val relType = options.relationshipMetadata.relationshipType.sanitizeSchemaName()
 
     session.executeRead(
       tx =>

--- a/src/main/scala/org/neo4j/spark/util/Neo4jImplicits.scala
+++ b/src/main/scala/org/neo4j/spark/util/Neo4jImplicits.scala
@@ -30,6 +30,7 @@ import org.apache.spark.sql.types.DataTypes
 import org.apache.spark.sql.types.MapType
 import org.apache.spark.sql.types.StructField
 import org.apache.spark.sql.types.StructType
+import org.neo4j.cypherdsl.support.schema_name.SchemaNames
 import org.neo4j.driver.Value
 import org.neo4j.driver.types.Entity
 import org.neo4j.driver.types.Node
@@ -42,18 +43,21 @@ import scala.jdk.CollectionConverters.MapHasAsJava
 import scala.jdk.CollectionConverters.MapHasAsScala
 import scala.jdk.CollectionConverters.SeqHasAsJava
 
-import javax.lang.model.SourceVersion
-
 object Neo4jImplicits {
 
+  private val BACKTICK = "`"
+
   implicit class CypherImplicits(str: String) {
-    private def isValidCypherIdentifier() = SourceVersion.isIdentifier(str) && !str.trim.startsWith("$")
 
-    def quote(): String = if (!isValidCypherIdentifier() && !str.isQuoted()) s"`$str`" else str
+    def sanitizeSchemaName(): String = {
+      if (str.startsWith(BACKTICK) && str.endsWith(BACKTICK)) {
+        SchemaNames.sanitize(str.substring(1, str.length - 1)).orElse("")
+      } else {
+        SchemaNames.sanitize(str).orElse("")
+      }
+    }
 
-    def unquote(): String = str.replaceAll("`", "");
-
-    def isQuoted(): Boolean = str.startsWith("`");
+    def unquote(): String = str.replaceAll(BACKTICK, "")
 
     def removeAlias(): String = {
       val splatString = str.unquote().split('.')
@@ -79,7 +83,7 @@ object Neo4jImplicits {
 
       val base64ed = java.util.Base64.getEncoder.encodeToString(attributeValue.getBytes())
 
-      s"${base64ed}_${str.unquote()}".quote()
+      s"${base64ed}_${str.unquote()}".sanitizeSchemaName()
     }
   }
 

--- a/src/test/scala/org/neo4j/spark/util/Neo4jImplicitsTest.scala
+++ b/src/test/scala/org/neo4j/spark/util/Neo4jImplicitsTest.scala
@@ -33,21 +33,19 @@ import org.neo4j.spark.util.Neo4jImplicits._
 
 import scala.collection.immutable.ListMap
 import scala.jdk.CollectionConverters.IterableHasAsJava
-import scala.jdk.CollectionConverters.ListHasAsScala
 import scala.jdk.CollectionConverters.MapHasAsJava
-import scala.jdk.CollectionConverters.MapHasAsScala
 import scala.jdk.CollectionConverters.SeqHasAsJava
 
 class Neo4jImplicitsTest {
 
   @Nested
-  class Quotes {
+  class Sanitizes {
 
     @Test
     def quotes_the_string(): Unit = {
       val value = "Test with space"
 
-      val actual = value.quote()
+      val actual = value.sanitizeSchemaName()
 
       assertThat(actual).isEqualTo(s"`$value`")
     }
@@ -56,25 +54,61 @@ class Neo4jImplicitsTest {
     def quotes_text_that_starts_with_$(): Unit = {
       val value = "$string"
 
-      val actual = value.quote()
+      val actual = value.sanitizeSchemaName()
 
-      assertThat(actual).isEqualTo(s"`$value`")
+      assertThat(actual).isEqualTo("`$string`")
+    }
+
+    @Test
+    def quotes_text_that_starts_with_$_even_when_quoted(): Unit = {
+      val value = "`$string`"
+
+      val actual = value.sanitizeSchemaName()
+
+      assertThat(actual).isEqualTo("`$string`")
+    }
+
+    @Test
+    def sanitizes_text_that_has_backtick(): Unit = {
+      val value = "User can put back`ticks"
+
+      val actual = value.sanitizeSchemaName()
+
+      assertThat(actual).isEqualTo(s"`User can put back``ticks`")
+    }
+
+    @Test
+    def sanitizes_text_that_has_backtick_and_no_spaces(): Unit = {
+      val value = "Per`son"
+
+      val actual = value.sanitizeSchemaName()
+
+      assertThat(actual).isEqualTo(s"`Per``son`")
     }
 
     @Test
     def does_not_requote_the_string(): Unit = {
       val value = "`Test with space`"
 
-      val actual = value.quote()
+      val actual = value.sanitizeSchemaName()
 
       assertThat(actual).isEqualTo(value)
+    }
+
+    @Test
+    def does_not_requote_the_string_even_when_sanitized(): Unit = {
+      val value = "`Test wi`th space`"
+
+      val actual = value.sanitizeSchemaName()
+
+      assertThat(actual).isEqualTo("`Test wi``th space`")
     }
 
     @Test
     def does_not_quote_the_string(): Unit = {
       val value = "Test"
 
-      val actual = value.quote()
+      val actual = value.sanitizeSchemaName()
 
       assertThat(actual).isEqualTo(value)
     }


### PR DESCRIPTION
The naive quotation function did not cover nested backticks. Which
makes it problematic to introduce property names, labels, rel types,
constraint names etc that has backticks in them.

By using Cypher DSL we introduce a more robust mechanic for escaping
identifier names.

Just using Cypher DSL creates a regressions:
 - Sanitize values that is already quoted e.g. "`test`"

Implemented in such way where this regression is not introduced to keep
backwards compatibility.