### PR TITLE
fix: labels containing spaces causes slowdown

### DIFF
--- a/common/src/main/scala/org/neo4j/spark/service/SchemaService.scala
+++ b/common/src/main/scala/org/neo4j/spark/service/SchemaService.scala
@@ -518,21 +518,23 @@ class SchemaService(
           .asInstanceOf[util.Map[String, Long]]
           .asScala
 
-        val minFromSource = options.relationshipMetadata.source.labels // no sanitization here - labels used as map keys
+        val sourceCounts = options.relationshipMetadata.source.labels // no sanitization here - labels used as map keys
           .map(label =>
             map.get(s"(:$label)-[:${options.relationshipMetadata.relationshipType}]->()")
           )
 
-        val minFromTarget = options.relationshipMetadata.target.labels // no sanitization here - labels used as map keys
+        val targetCounts = options.relationshipMetadata.target.labels // no sanitization here - labels used as map keys
           .map(label =>
             map.get(s"()-[:${options.relationshipMetadata.relationshipType}]->(:$label)")
           )
 
-        if (minFromSource.contains(None) || minFromTarget.contains(None)) {
-          logResolutionChange("Count store lookup incomplete. Switching to query count resolution", null)
+        val validCounts = (sourceCounts ++ targetCounts).flatten
+
+        if (validCounts.isEmpty) {
+          logResolutionChange("Count store lookup failed. Switching to query count resolution", null)
           countForRelationshipWithQuery(filters)
         } else {
-          Math.min(minFromSource.flatten.min, minFromTarget.flatten.min)
+          validCounts.min
         }
       } else {
         countForRelationshipWithQuery(filters)

--- a/common/src/main/scala/org/neo4j/spark/service/SchemaService.scala
+++ b/common/src/main/scala/org/neo4j/spark/service/SchemaService.scala
@@ -517,19 +517,23 @@ class SchemaService(
           .getOrElse(Collections.emptyMap())
           .asInstanceOf[util.Map[String, Long]]
           .asScala
-        val minFromSource = options.relationshipMetadata.source.labels
-          .map(_.quote())
+
+        val minFromSource = options.relationshipMetadata.source.labels // no sanitization here - labels used as map keys
           .map(label =>
-            map.get(s"(:$label)-[:${options.relationshipMetadata.relationshipType}]->()").getOrElse(Long.MaxValue)
+            map.get(s"(:$label)-[:${options.relationshipMetadata.relationshipType}]->()")
           )
-          .min
-        val minFromTarget = options.relationshipMetadata.target.labels
-          .map(_.quote())
+
+        val minFromTarget = options.relationshipMetadata.target.labels // no sanitization here - labels used as map keys
           .map(label =>
-            map.get(s"()-[:${options.relationshipMetadata.relationshipType}]->(:$label)").getOrElse(Long.MaxValue)
+            map.get(s"()-[:${options.relationshipMetadata.relationshipType}]->(:$label)")
           )
-          .min
-        Math.min(minFromSource, minFromTarget)
+
+        if (minFromSource.contains(None) || minFromTarget.contains(None)) {
+          logResolutionChange("Count store lookup incomplete. Switching to query count resolution", null)
+          countForRelationshipWithQuery(filters)
+        } else {
+          Math.min(minFromSource.flatten.min, minFromTarget.flatten.min)
+        }
       } else {
         countForRelationshipWithQuery(filters)
       }
@@ -553,6 +557,7 @@ class SchemaService(
       Seq(skipLimit)
     } else {
       val count: Long = this.count()
+
       if (count <= 0) {
         Seq(PartitionPagination.EMPTY)
       } else {
@@ -1009,7 +1014,8 @@ class SchemaService(
 
   private def logResolutionChange(message: String, e: ClientException): Unit = {
     log.warn(message)
-    if (!e.code().equals("Neo.ClientError.Procedure.ProcedureNotFound")) {
+
+    if (e != null && !e.code().equals("Neo.ClientError.Procedure.ProcedureNotFound")) {
       log.warn(s"For the following exception", e)
     }
   }

--- a/common/src/test/scala/org/neo4j/spark/service/SchemaServiceTSE.scala
+++ b/common/src/test/scala/org/neo4j/spark/service/SchemaServiceTSE.scala
@@ -25,10 +25,6 @@ import org.junit.FixMethodOrder
 import org.junit.Test
 import org.junit.runners.MethodSorters
 import org.neo4j.Closeables.use
-import org.neo4j.caniuse.Neo4j
-import org.neo4j.caniuse.Neo4jDeploymentType
-import org.neo4j.caniuse.Neo4jEdition
-import org.neo4j.caniuse.Neo4jVersion
 import org.neo4j.driver.Transaction
 import org.neo4j.driver.TransactionWork
 import org.neo4j.driver.summary.ResultSummary
@@ -42,7 +38,6 @@ import org.neo4j.spark.util.Neo4jUtil
 import org.neo4j.spark.util.QueryType
 
 import java.util
-import java.util.UUID
 
 @FixMethodOrder(MethodSorters.JVM)
 class SchemaServiceTSE extends SparkConnectorScalaBaseTSE {

--- a/common/src/test/scala/org/neo4j/spark/service/SchemaServiceTest.scala
+++ b/common/src/test/scala/org/neo4j/spark/service/SchemaServiceTest.scala
@@ -28,7 +28,6 @@ import org.neo4j.spark.config.TopN
 import org.neo4j.spark.util.DriverCache
 import org.neo4j.spark.util.Neo4jOptions
 
-import scala.annotation.nowarn
 import scala.collection.JavaConverters
 
 class SchemaServiceTest {

--- a/common/src/test/scala/org/neo4j/spark/service/SchemaServiceWithApocTSE.scala
+++ b/common/src/test/scala/org/neo4j/spark/service/SchemaServiceWithApocTSE.scala
@@ -16,6 +16,7 @@
  */
 package org.neo4j.spark.service
 
+import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.DataTypes
 import org.apache.spark.sql.types.StructField
 import org.apache.spark.sql.types.StructType
@@ -218,7 +219,7 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
       CREATE (p1:Person {age: 31, name: 'Jane Doe'}),
         (p2:Person {name: 'John Doe', age: 33, location: null}),
         (p3:Person {age: 25, location: point({latitude: 12.12, longitude: 31.13})})
-    """
+      """
     )
 
     val options: java.util.Map[String, String] = new util.HashMap[String, String]()
@@ -239,24 +240,18 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
   @Test
   def testPageMathWhenCorruptedNodeIdentifiers(): Unit = {
     // given
-    val setUp =
+    initTest(
       """
-        |CREATE (:`Person with spaces` {name: "Alice"})-[:KNOWS]->(:`Person with spaces` {name: "Bob"})
-        |CREATE (:`Person with spaces` {name: "Bob"})-[:KNOWS]->(:`Person with spaces` {name: "Alice"})
-        |CREATE (:`Person with spaces` {name: "Alice"})-[:KNOWS]->(:`Person with spaces` {name: "Charlie"})
-        |CREATE (:`Person with spaces` {name: "Charlie"})-[:KNOWS]->(:`Person with spaces` {name: "Alice"})
-        |CREATE (:`Person with spaces` {name: "Bob"})-[:KNOWS]->(:`Person with spaces` {name: "Charlie"})
-        |CREATE (:`Person with spaces` {name: "Charlie"})-[:KNOWS]->(:`Person with spaces` {name: "Bob"})
-        |""".stripMargin
+      CREATE (:`Person with spaces` {name: "A"})-[:KNOWS]->(:`Person with spaces` {name: "B"})
+      CREATE (:`Person with spaces` {name: "B"})-[:KNOWS]->(:`Person with spaces` {name: "A"})
+      CREATE (:`Person with spaces` {name: "A"})-[:KNOWS]->(:`Person with spaces` {name: "C"})
+      CREATE (:`Person with spaces` {name: "C"})-[:KNOWS]->(:`Person with spaces` {name: "A"})
+      CREATE (:`Person with spaces` {name: "B"})-[:KNOWS]->(:`Person with spaces` {name: "C"})
+      CREATE (:`Person with spaces` {name: "C"})-[:KNOWS]->(:`Person with spaces` {name: "B"})
+     """
+    )
 
-    val desiredPartitions = 3
-
-    SparkConnectorScalaSuiteWithApocIT.session()
-      .writeTransaction(
-        new TransactionWork[ResultSummary] {
-          override def execute(tx: Transaction): ResultSummary = tx.run(setUp).consume()
-        }
-      )
+    val desiredPartitions = 2
 
     val options: java.util.Map[String, String] = new util.HashMap[String, String]()
     options.put(QueryType.RELATIONSHIP.toString.toLowerCase, "KNOWS")
@@ -267,13 +262,21 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
     val neo4jOptions = new Neo4jOptions(options)
     val driverCache = new DriverCache(neo4jOptions.connection)
     val neo4j = new Neo4j(new Neo4jVersion(5, 26, 0), Neo4jEdition.ENTERPRISE, Neo4jDeploymentType.SELF_MANAGED)
-    val schemaService: SchemaService = new SchemaService(neo4j, neo4jOptions, driverCache)
+    val schemaService = new SchemaServiceFallbackSpy(neo4j, neo4jOptions, driverCache)
 
-    // when
-    val pages = schemaService.skipLimitFromPartition(Some(TopN(2)))
+    try {
+      // when
+      val pages = schemaService.skipLimitFromPartition(Some(TopN(2)))
 
-    // then
-    assertEquals(desiredPartitions, pages.size)
+      // then -- 2 pages of size 3
+      assertEquals(desiredPartitions, pages.size)
+      assertEquals(0, pages.head.skip)
+      assertEquals(3, pages.last.skip)
+      assertEquals(0, schemaService.fallbackCount)
+    } finally {
+      schemaService.close()
+      driverCache.close()
+    }
   }
 
   private def getExpectedStructType(structFields: Seq[StructField]): StructType = {
@@ -306,5 +309,21 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
     driverCache.close()
 
     schema
+  }
+
+  private class SchemaServiceFallbackSpy(neo4j: Neo4j, options: Neo4jOptions, driverCache: DriverCache)
+      extends SchemaService(neo4j, options, driverCache) {
+
+    var fallbackCount: Int = 0
+
+    override def countForNodeWithQuery(filters: Array[Filter]): Long = {
+      fallbackCount += 1
+      super.countForNodeWithQuery(filters)
+    }
+
+    override def countForRelationshipWithQuery(filters: Array[Filter]): Long = {
+      fallbackCount += 1
+      super.countForRelationshipWithQuery(filters)
+    }
   }
 }

--- a/common/src/test/scala/org/neo4j/spark/service/SchemaServiceWithApocTSE.scala
+++ b/common/src/test/scala/org/neo4j/spark/service/SchemaServiceWithApocTSE.scala
@@ -34,6 +34,7 @@ import org.neo4j.driver.TransactionWork
 import org.neo4j.driver.summary.ResultSummary
 import org.neo4j.spark.SparkConnectorScalaBaseWithApocTSE
 import org.neo4j.spark.SparkConnectorScalaSuiteWithApocIT
+import org.neo4j.spark.config.TopN
 import org.neo4j.spark.converter.CypherToSparkTypeConverter
 import org.neo4j.spark.util.DriverCache
 import org.neo4j.spark.util.Neo4jOptions
@@ -233,6 +234,46 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
       )),
       schema
     )
+  }
+
+  @Test
+  def testPageMathWhenCorruptedNodeIdentifiers(): Unit = {
+    // given
+    val setUp =
+      """
+        |CREATE (:`Person with spaces` {name: "Alice"})-[:KNOWS]->(:`Person with spaces` {name: "Bob"})
+        |CREATE (:`Person with spaces` {name: "Bob"})-[:KNOWS]->(:`Person with spaces` {name: "Alice"})
+        |CREATE (:`Person with spaces` {name: "Alice"})-[:KNOWS]->(:`Person with spaces` {name: "Charlie"})
+        |CREATE (:`Person with spaces` {name: "Charlie"})-[:KNOWS]->(:`Person with spaces` {name: "Alice"})
+        |CREATE (:`Person with spaces` {name: "Bob"})-[:KNOWS]->(:`Person with spaces` {name: "Charlie"})
+        |CREATE (:`Person with spaces` {name: "Charlie"})-[:KNOWS]->(:`Person with spaces` {name: "Bob"})
+        |""".stripMargin
+
+    val desiredParititions = 3
+
+    SparkConnectorScalaSuiteWithApocIT.session()
+      .writeTransaction(
+        new TransactionWork[ResultSummary] {
+          override def execute(tx: Transaction): ResultSummary = tx.run(setUp).consume()
+        }
+      )
+
+    val options: java.util.Map[String, String] = new util.HashMap[String, String]()
+    options.put(QueryType.RELATIONSHIP.toString.toLowerCase, "KNOWS")
+    options.put(Neo4jOptions.RELATIONSHIP_SOURCE_LABELS, "Person with spaces")
+    options.put(Neo4jOptions.URL, SparkConnectorScalaSuiteWithApocIT.server.getBoltUrl)
+    options.put(Neo4jOptions.PARTITIONS, desiredParititions.toString)
+
+    val neo4jOptions = new Neo4jOptions(options)
+    val driverCache = new DriverCache(neo4jOptions.connection)
+    val neo4j = new Neo4j(new Neo4jVersion(5, 26, 0), Neo4jEdition.ENTERPRISE, Neo4jDeploymentType.SELF_MANAGED)
+    val schemaService: SchemaService = new SchemaService(neo4j, neo4jOptions, driverCache)
+
+    // when
+    val pages = schemaService.skipLimitFromPartition(Some(TopN(2)))
+
+    // then
+    assertEquals(desiredParititions, pages.size)
   }
 
   private def getExpectedStructType(structFields: Seq[StructField]): StructType = {

--- a/common/src/test/scala/org/neo4j/spark/service/SchemaServiceWithApocTSE.scala
+++ b/common/src/test/scala/org/neo4j/spark/service/SchemaServiceWithApocTSE.scala
@@ -249,7 +249,7 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
         |CREATE (:`Person with spaces` {name: "Charlie"})-[:KNOWS]->(:`Person with spaces` {name: "Bob"})
         |""".stripMargin
 
-    val desiredParititions = 3
+    val desiredPartitions = 3
 
     SparkConnectorScalaSuiteWithApocIT.session()
       .writeTransaction(
@@ -262,7 +262,7 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
     options.put(QueryType.RELATIONSHIP.toString.toLowerCase, "KNOWS")
     options.put(Neo4jOptions.RELATIONSHIP_SOURCE_LABELS, "Person with spaces")
     options.put(Neo4jOptions.URL, SparkConnectorScalaSuiteWithApocIT.server.getBoltUrl)
-    options.put(Neo4jOptions.PARTITIONS, desiredParititions.toString)
+    options.put(Neo4jOptions.PARTITIONS, desiredPartitions.toString)
 
     val neo4jOptions = new Neo4jOptions(options)
     val driverCache = new DriverCache(neo4jOptions.connection)
@@ -273,7 +273,7 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
     val pages = schemaService.skipLimitFromPartition(Some(TopN(2)))
 
     // then
-    assertEquals(desiredParititions, pages.size)
+    assertEquals(desiredPartitions, pages.size)
   }
 
   private def getExpectedStructType(structFields: Seq[StructField]): StructType = {

--- a/common/src/test/scala/org/neo4j/spark/service/SchemaServiceWithApocTSE.scala
+++ b/common/src/test/scala/org/neo4j/spark/service/SchemaServiceWithApocTSE.scala
@@ -43,7 +43,6 @@ import org.neo4j.spark.util.Neo4jUtil
 import org.neo4j.spark.util.QueryType
 
 import java.util
-import java.util.UUID
 
 @FixMethodOrder(MethodSorters.JVM)
 class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
@@ -238,8 +237,9 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
   }
 
   @Test
-  def testPageMathWhenCorruptedNodeIdentifiers(): Unit = {
-    // given
+  def testPageMathForRelsWhenEscapedNodeIdentifiers(): Unit = {
+    val desiredPartitions = 2
+
     initTest(
       """
       CREATE (:`Person with spaces` {name: "A"})-[:KNOWS]->(:`Person with spaces` {name: "B"})
@@ -251,27 +251,73 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
      """
     )
 
-    val desiredPartitions = 2
-
     val options: java.util.Map[String, String] = new util.HashMap[String, String]()
     options.put(QueryType.RELATIONSHIP.toString.toLowerCase, "KNOWS")
     options.put(Neo4jOptions.RELATIONSHIP_SOURCE_LABELS, "Person with spaces")
+    options.put(Neo4jOptions.RELATIONSHIP_TARGET_LABELS, "Person with spaces")
     options.put(Neo4jOptions.URL, SparkConnectorScalaSuiteWithApocIT.server.getBoltUrl)
     options.put(Neo4jOptions.PARTITIONS, desiredPartitions.toString)
 
     val neo4jOptions = new Neo4jOptions(options)
     val driverCache = new DriverCache(neo4jOptions.connection)
-    val neo4j = new Neo4j(new Neo4jVersion(5, 26, 0), Neo4jEdition.ENTERPRISE, Neo4jDeploymentType.SELF_MANAGED)
+    val neo4j = new Neo4j(new Neo4jVersion(4, 4, 0), Neo4jEdition.ENTERPRISE, Neo4jDeploymentType.SELF_MANAGED)
     val schemaService = new SchemaServiceFallbackSpy(neo4j, neo4jOptions, driverCache)
 
     try {
-      // when
       val pages = schemaService.skipLimitFromPartition(Some(TopN(2)))
 
-      // then -- 2 pages of size 3
-      assertEquals(desiredPartitions, pages.size)
-      assertEquals(0, pages.head.skip)
-      assertEquals(3, pages.last.skip)
+      // two pages of size 3 with no query fallback
+      assertEquals(
+        Seq(
+          PartitionPagination(0, 0, TopN(3)),
+          PartitionPagination(1, 3, TopN(3))
+        ),
+        pages
+      )
+      assertEquals(0, schemaService.fallbackCount)
+    } finally {
+      schemaService.close()
+      driverCache.close()
+    }
+  }
+
+  @Test
+  def testPageMathForRelsWhenMatchingOnOneNode(): Unit = {
+    val desiredPartitions = 2
+
+    initTest(
+      """
+      CREATE (:Person {name: "A"})-[:KNOWS]->(:Person {name: "B"})
+      CREATE (:Person {name: "B"})-[:KNOWS]->(:Person {name: "A"})
+      CREATE (:Person {name: "A"})-[:KNOWS]->(:Person {name: "C"})
+      CREATE (:Person {name: "C"})-[:KNOWS]->(:Person {name: "A"})
+      CREATE (:Person {name: "B"})-[:KNOWS]->(:Person {name: "C"})
+      CREATE (:Person {name: "C"})-[:KNOWS]->(:Person {name: "B"})
+     """
+    )
+
+    val options: java.util.Map[String, String] = new util.HashMap[String, String]()
+    options.put(QueryType.RELATIONSHIP.toString.toLowerCase, "KNOWS")
+    options.put(Neo4jOptions.RELATIONSHIP_SOURCE_LABELS, "Person")
+    options.put(Neo4jOptions.URL, SparkConnectorScalaSuiteWithApocIT.server.getBoltUrl)
+    options.put(Neo4jOptions.PARTITIONS, desiredPartitions.toString)
+
+    val neo4jOptions = new Neo4jOptions(options)
+    val driverCache = new DriverCache(neo4jOptions.connection)
+    val neo4j = new Neo4j(new Neo4jVersion(4, 4, 0), Neo4jEdition.ENTERPRISE, Neo4jDeploymentType.SELF_MANAGED)
+    val schemaService = new SchemaServiceFallbackSpy(neo4j, neo4jOptions, driverCache)
+
+    try {
+      val pages = schemaService.skipLimitFromPartition(Some(TopN(2)))
+
+      // two pages of size 3 with no query fallback
+      assertEquals(
+        Seq(
+          PartitionPagination(0, 0, TopN(3)),
+          PartitionPagination(1, 3, TopN(3))
+        ),
+        pages
+      )
       assertEquals(0, schemaService.fallbackCount)
     } finally {
       schemaService.close()

--- a/common/src/test/scala/org/neo4j/spark/service/SchemaServiceWithApocTSE.scala
+++ b/common/src/test/scala/org/neo4j/spark/service/SchemaServiceWithApocTSE.scala
@@ -267,13 +267,10 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
       val pages = schemaService.skipLimitFromPartition(Some(TopN(2)))
 
       // two pages of size 3 with no query fallback
-      assertEquals(
-        Seq(
-          PartitionPagination(0, 0, TopN(3)),
-          PartitionPagination(1, 3, TopN(3))
-        ),
-        pages
-      )
+      assertEquals(0, pages.head.partitionNumber)
+      assertEquals(0, pages.head.skip)
+      assertEquals(1, pages.last.partitionNumber)
+      assertEquals(3, pages.last.skip)
       assertEquals(0, schemaService.fallbackCount)
     } finally {
       schemaService.close()
@@ -311,13 +308,10 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
       val pages = schemaService.skipLimitFromPartition(Some(TopN(2)))
 
       // two pages of size 3 with no query fallback
-      assertEquals(
-        Seq(
-          PartitionPagination(0, 0, TopN(3)),
-          PartitionPagination(1, 3, TopN(3))
-        ),
-        pages
-      )
+      assertEquals(0, pages.head.partitionNumber)
+      assertEquals(0, pages.head.skip)
+      assertEquals(1, pages.last.partitionNumber)
+      assertEquals(3, pages.last.skip)
       assertEquals(0, schemaService.fallbackCount)
     } finally {
       schemaService.close()


### PR DESCRIPTION
Before, we sanitized/escaped/quoted the key used to look-up the
returned map from `apoc.meta.stats()`. However, Cypher produces these
keys as non-escaped string values. So if we escape the predicted key,
we will never match the produced APOC key.

The symptom of this state is: instead of error and fall back to count
query, we use Long.Max value for each executor's pagination. Causing
each worker thread to scan the whole graph, causing slowdown.

This PR fixes the error state such that we do not escape the key.
In the case where no matches was found, we fall back to query.