### PR TITLE
fix: labels containing spaces causes slowdown

### DIFF
--- a/src/main/scala/org/neo4j/spark/service/SchemaService.scala
+++ b/src/main/scala/org/neo4j/spark/service/SchemaService.scala
@@ -531,19 +531,25 @@ class SchemaService(
           .getOrElse(Collections.emptyMap())
           .asInstanceOf[util.Map[String, Long]]
           .asScala
-        val minFromSource = options.relationshipMetadata.source.labels
-          .map(_.quote())
+
+        val sourceCounts = options.relationshipMetadata.source.labels // no sanitization here - labels used as map keys
           .map(label =>
-            map.get(s"(:$label)-[:${options.relationshipMetadata.relationshipType}]->()").getOrElse(Long.MaxValue)
+            map.get(s"(:$label)-[:${options.relationshipMetadata.relationshipType}]->()")
           )
-          .min
-        val minFromTarget = options.relationshipMetadata.target.labels
-          .map(_.quote())
+
+        val targetCounts = options.relationshipMetadata.target.labels // no sanitization here - labels used as map keys
           .map(label =>
-            map.get(s"()-[:${options.relationshipMetadata.relationshipType}]->(:$label)").getOrElse(Long.MaxValue)
+            map.get(s"()-[:${options.relationshipMetadata.relationshipType}]->(:$label)")
           )
-          .min
-        Math.min(minFromSource, minFromTarget)
+
+        val validCounts = (sourceCounts ++ targetCounts).flatten
+
+        if (validCounts.isEmpty) {
+          logResolutionChange("Count store lookup failed. Switching to query count resolution", null)
+          countForRelationshipWithQuery(filters)
+        } else {
+          validCounts.min
+        }
       } else {
         countForRelationshipWithQuery(filters)
       }
@@ -567,6 +573,7 @@ class SchemaService(
       Seq(skipLimit)
     } else {
       val count: Long = this.count()
+
       if (count <= 0) {
         Seq(PartitionPagination.EMPTY)
       } else {
@@ -952,7 +959,8 @@ class SchemaService(
 
   private def logResolutionChange(message: String, e: ClientException): Unit = {
     log.warn(message)
-    if (!e.code().equals("Neo.ClientError.Procedure.ProcedureNotFound")) {
+
+    if (e != null && !e.code().equals("Neo.ClientError.Procedure.ProcedureNotFound")) {
       log.warn(s"For the following exception", e)
     }
   }

--- a/src/test/scala/org/neo4j/spark/service/SchemaServiceWithApocTSE.scala
+++ b/src/test/scala/org/neo4j/spark/service/SchemaServiceWithApocTSE.scala
@@ -16,6 +16,7 @@
  */
 package org.neo4j.spark.service
 
+import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.DataTypes
 import org.apache.spark.sql.types.StructField
 import org.apache.spark.sql.types.StructType
@@ -27,6 +28,7 @@ import org.neo4j.caniuse.Neo4jDeploymentType
 import org.neo4j.caniuse.Neo4jEdition
 import org.neo4j.caniuse.Neo4jVersion
 import org.neo4j.driver.TransactionContext
+import org.neo4j.spark.config.TopN
 import org.neo4j.spark.converter.CypherToSparkTypeConverter
 import org.neo4j.spark.testsupport.Closeables.use
 import org.neo4j.spark.testsupport.SparkConnectorScalaBaseWithApocTSE
@@ -185,7 +187,7 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
       CREATE (p1:Person {age: 31, name: 'Jane Doe'}),
         (p2:Person {name: 'John Doe', age: 33, location: null}),
         (p3:Person {age: 25, location: point({latitude: 12.12, longitude: 31.13})})
-    """
+      """
     )
     val options = Map(QueryType.LABELS.toString.toLowerCase -> "Person")
     val schema = getSchema(options)
@@ -198,6 +200,101 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
       )),
       schema
     )
+  }
+
+  @Test
+  def testPageMathForRelsWhenEscapedNodeIdentifiers(): Unit = {
+    val desiredPartitions = 2
+
+    initTest(
+      """
+      CREATE (:`Person with spaces` {name: "A"})-[:KNOWS]->(:`Person with spaces` {name: "B"})
+      CREATE (:`Person with spaces` {name: "B"})-[:KNOWS]->(:`Person with spaces` {name: "A"})
+      CREATE (:`Person with spaces` {name: "A"})-[:KNOWS]->(:`Person with spaces` {name: "C"})
+      CREATE (:`Person with spaces` {name: "C"})-[:KNOWS]->(:`Person with spaces` {name: "A"})
+      CREATE (:`Person with spaces` {name: "B"})-[:KNOWS]->(:`Person with spaces` {name: "C"})
+      CREATE (:`Person with spaces` {name: "C"})-[:KNOWS]->(:`Person with spaces` {name: "B"})
+     """
+    )
+
+    val options = Map(
+      QueryType.RELATIONSHIP.toString.toLowerCase -> "KNOWS",
+      Neo4jOptions.RELATIONSHIP_SOURCE_LABELS -> "Person with spaces",
+      Neo4jOptions.RELATIONSHIP_TARGET_LABELS -> "Person with spaces",
+      Neo4jOptions.URL -> SparkConnectorScalaSuiteWithApocIT.server.getBoltUrl,
+      Neo4jOptions.PARTITIONS -> desiredPartitions.toString
+    )
+
+    val neo4jOptions = new Neo4jOptions(options)
+    val driverCache = new DriverCache(neo4jOptions.connection)
+    val neo4j = new Neo4j(
+      new Neo4jVersion(5, 26, 0),
+      Neo4jEdition.ENTERPRISE,
+      Neo4jDeploymentType.SELF_MANAGED,
+      Collections.emptySet()
+    )
+    val schemaService = new SchemaServiceFallbackSpy(neo4j, neo4jOptions, driverCache)
+
+    try {
+      val pages = schemaService.skipLimitFromPartition(Some(TopN(2)))
+
+      // two pages of size 3 with no query fallback
+      assertEquals(0, pages.head.partitionNumber)
+      assertEquals(0, pages.head.skip)
+      assertEquals(1, pages.last.partitionNumber)
+      assertEquals(3, pages.last.skip)
+      assertEquals(0, schemaService.fallbackCount)
+    } finally {
+      schemaService.close()
+      driverCache.close()
+    }
+  }
+
+  @Test
+  def testPageMathForRelsWhenMatchingOnOneNode(): Unit = {
+    val desiredPartitions = 2
+
+    initTest(
+      """
+      CREATE (:Person {name: "A"})-[:KNOWS]->(:Person {name: "B"})
+      CREATE (:Person {name: "B"})-[:KNOWS]->(:Person {name: "A"})
+      CREATE (:Person {name: "A"})-[:KNOWS]->(:Person {name: "C"})
+      CREATE (:Person {name: "C"})-[:KNOWS]->(:Person {name: "A"})
+      CREATE (:Person {name: "B"})-[:KNOWS]->(:Person {name: "C"})
+      CREATE (:Person {name: "C"})-[:KNOWS]->(:Person {name: "B"})
+     """
+    )
+
+    val options = Map(
+      QueryType.RELATIONSHIP.toString.toLowerCase -> "KNOWS",
+      Neo4jOptions.RELATIONSHIP_SOURCE_LABELS -> "Person",
+      Neo4jOptions.URL -> SparkConnectorScalaSuiteWithApocIT.server.getBoltUrl,
+      Neo4jOptions.PARTITIONS -> desiredPartitions.toString
+    )
+
+    val neo4jOptions = new Neo4jOptions(options)
+    val driverCache = new DriverCache(neo4jOptions.connection)
+    val neo4j = new Neo4j(
+      new Neo4jVersion(4, 4, 0),
+      Neo4jEdition.ENTERPRISE,
+      Neo4jDeploymentType.SELF_MANAGED,
+      Collections.emptySet()
+    )
+    val schemaService = new SchemaServiceFallbackSpy(neo4j, neo4jOptions, driverCache)
+
+    try {
+      val pages = schemaService.skipLimitFromPartition(Some(TopN(2)))
+
+      // two pages of size 3 with no query fallback
+      assertEquals(0, pages.head.partitionNumber)
+      assertEquals(0, pages.head.skip)
+      assertEquals(1, pages.last.partitionNumber)
+      assertEquals(3, pages.last.skip)
+      assertEquals(0, schemaService.fallbackCount)
+    } finally {
+      schemaService.close()
+      driverCache.close()
+    }
   }
 
   private def getExpectedStructType(structFields: Seq[StructField]): StructType = {
@@ -231,5 +328,21 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
     driverCache.close()
 
     schema
+  }
+
+  private class SchemaServiceFallbackSpy(neo4j: Neo4j, options: Neo4jOptions, driverCache: DriverCache)
+      extends SchemaService(neo4j, options, driverCache) {
+
+    var fallbackCount: Int = 0
+
+    override def countForNodeWithQuery(filters: Array[Filter]): Long = {
+      fallbackCount += 1
+      super.countForNodeWithQuery(filters)
+    }
+
+    override def countForRelationshipWithQuery(filters: Array[Filter]): Long = {
+      fallbackCount += 1
+      super.countForRelationshipWithQuery(filters)
+    }
   }
 }


### PR DESCRIPTION
Before, we sanitized/escaped/quoted the key used to look-up the
returned map from `apoc.meta.stats()`. However, Cypher produces these
keys as non-escaped string values. So if we escape the predicted key,
we will never match the produced APOC key.

The symptom of this state is: instead of error and fall back to count
query, we use Long.Max value for each executor's pagination. Causing
each worker thread to scan the whole graph, causing slowdown.

This PR fixes the error state such that we do not escape the key.
In the case where no matches was found, we fall back to query.

Cherry-picked from: af56e2255ba91dc83b5cc3623a62591a009c2a1e