### PR TITLE
fix: resolve an ambiguity between alias separation and dots in property names

### DIFF
--- a/src/main/scala/org/neo4j/spark/service/MappingService.scala
+++ b/src/main/scala/org/neo4j/spark/service/MappingService.scala
@@ -74,18 +74,18 @@ class Neo4jWriteMappingStrategy(private val options: Neo4jOptions)
 
     override def accept(key: String, value: AnyRef): Unit = {
       if (key.startsWith(Neo4jUtil.RELATIONSHIP_ALIAS.concat("."))) {
-        relMap.get(PROPERTIES).put(key.removeAlias(), value)
+        relMap.get(PROPERTIES).put(key.removeEntityAlias(Neo4jUtil.RELATIONSHIP_ALIAS), value)
       } else if (key.startsWith(Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS.concat("."))) {
         if (options.relationshipMetadata.source.nodeKeys.contains(key)) {
-          sourceNodeMap.get(KEYS).put(key.removeAlias(), value)
+          sourceNodeMap.get(KEYS).put(key.removeEntityAlias(Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS), value)
         } else {
-          sourceNodeMap.get(PROPERTIES).put(key.removeAlias(), value)
+          sourceNodeMap.get(PROPERTIES).put(key.removeEntityAlias(Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS), value)
         }
       } else if (key.startsWith(Neo4jUtil.RELATIONSHIP_TARGET_ALIAS.concat("."))) {
         if (options.relationshipMetadata.target.nodeKeys.contains(key)) {
-          targetNodeMap.get(KEYS).put(key.removeAlias(), value)
+          targetNodeMap.get(KEYS).put(key.removeEntityAlias(Neo4jUtil.RELATIONSHIP_TARGET_ALIAS), value)
         } else {
-          targetNodeMap.get(PROPERTIES).put(key.removeAlias(), value)
+          targetNodeMap.get(PROPERTIES).put(key.removeEntityAlias(Neo4jUtil.RELATIONSHIP_TARGET_ALIAS), value)
         }
       }
     }

--- a/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
+++ b/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
@@ -26,14 +26,7 @@ import org.apache.spark.sql.sources.And
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.sources.Or
 import org.neo4j.caniuse.Neo4j
-import org.neo4j.cypherdsl.core.Cypher.callRawCypher
 import org.neo4j.cypherdsl.core._
-import org.neo4j.cypherdsl.core.renderer.Configuration
-import org.neo4j.cypherdsl.core.renderer.GeneralizedRenderer
-import org.neo4j.cypherdsl.core.renderer.Renderer
-import org.neo4j.cypherdsl.parser.CypherParser
-import org.neo4j.cypherdsl.parser.ExpressionCreatedEventType
-import org.neo4j.cypherdsl.parser.Options
 import org.neo4j.spark.cypher.CypherPreamble.fullPreamble
 import org.neo4j.spark.cypher.CypherRenderer
 import org.neo4j.spark.cypher.QueryEmbedder
@@ -265,23 +258,17 @@ class Neo4jQueryReadStrategy(
   private def convertSort(entity: PropertyContainer, order: SortOrder): SortItem = {
     val sortExpression = order.expression().describe()
 
-    val container: Option[PropertyContainer] = entity match {
-      case relationship: Relationship =>
-        if (sortExpression.contains(s"${Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS}.")) {
-          Some(relationship.getLeft)
-        } else if (sortExpression.contains(s"${Neo4jUtil.RELATIONSHIP_TARGET_ALIAS}.")) {
-          Some(relationship.getRight)
-        } else if (sortExpression.contains(s"${Neo4jUtil.RELATIONSHIP_ALIAS}.")) {
-          Some(relationship)
-        } else {
-          None
-        }
-      case _ => Some(entity)
+    val container: Option[(PropertyContainer, Option[String])] = entity match {
+      case relationship: Relationship => entityAlias(sortExpression)
+          .map(alias => (relationshipContainer(alias, relationship), Some(alias)))
+      case _ => Some((entity, None))
     }
 
     Cypher.sort(
       container
-        .map(_.property(sortExpression.removeAlias()))
+        .map { case (propertyContainer, alias) =>
+          Neo4jUtil.getCorrectProperty(propertyContainer, sortExpression, alias)
+        }
         .getOrElse(Cypher.name(sortExpression.unquote())),
       direction(order)
     )
@@ -304,29 +291,66 @@ class Neo4jQueryReadStrategy(
       )
     } else {
       requiredColumns.map(column => {
-        val splatColumn = column.split('.')
-        val entityName = splatColumn.head
+        // an aggregation is named after the function, e.g. `SUM(``target.price``)`, so the entity
+        // it belongs to has to be resolved from the column the aggregation is computed on
+        val alias = columnEntityAlias(aggregatedColumn(column).getOrElse(column))
 
-        val entity = if (entityName.contains(Neo4jUtil.RELATIONSHIP_ALIAS)) {
-          relationship
-        } else if (entityName.contains(Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS)) {
-          sourceNode
-        } else if (entityName.contains(Neo4jUtil.RELATIONSHIP_TARGET_ALIAS)) {
-          targetNode
-        } else {
-          null
-        }
+        val entity = alias
+          .map {
+            case Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS => sourceNode
+            case Neo4jUtil.RELATIONSHIP_TARGET_ALIAS => targetNode
+            case _                                   => relationship
+          }
+          .orNull
 
-        if (entity != null && splatColumn.length == 1) {
+        val name = column.unquote()
+        if (entity != null && alias.exists(a => name == a || name == s"<$a>")) {
           entity match {
-            case n: Node         => n.as(entityName.quote())
+            case n: Node         => n.as(column.quote())
             case r: Relationship => r.getRequiredSymbolicName
           }
         } else {
-          getCorrectProperty(column, entity)
+          getCorrectProperty(column, entity, alias)
         }
       })
     }
+  }
+
+  private val relationshipAliases =
+    Seq(Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS, Neo4jUtil.RELATIONSHIP_TARGET_ALIAS, Neo4jUtil.RELATIONSHIP_ALIAS)
+
+  /**
+   * The column an aggregation is computed on, e.g. `` `target.price` `` for
+   * `` SUM(`target.price`) ``. Aggregations over the whole row, like `COUNT(*)`, have none.
+   */
+  private def aggregatedColumn(column: String): Option[String] = aggregateColumns
+    .find(_.toString == column)
+    .flatMap {
+      case count: Count => Some(count.column().describe())
+      case max: Max     => Some(max.column().describe())
+      case min: Min     => Some(min.column().describe())
+      case sum: Sum     => Some(sum.column().describe())
+      case _            => None
+    }
+
+  /**
+   * Returns the alias of the relationship entity the given column is prefixed with, if any.
+   */
+  private def entityAlias(column: String): Option[String] = relationshipAliases.find(column.hasEntityAlias)
+
+  /**
+   * Same as [[entityAlias]], but it also recognises the internal fields, which wrap the alias in
+   * angle brackets, e.g. `<source.elementId>` or `<source>`.
+   */
+  private def columnEntityAlias(column: String): Option[String] = {
+    val name = column.unquote().stripPrefix("<")
+    relationshipAliases.find(alias => name == alias || name == s"$alias>" || name.hasEntityAlias(alias))
+  }
+
+  private def relationshipContainer(alias: String, relationship: Relationship): PropertyContainer = alias match {
+    case Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS => relationship.getLeft
+    case Neo4jUtil.RELATIONSHIP_TARGET_ALIAS => relationship.getRight
+    case _                                   => relationship
   }
 
   private def buildStatementAggregation(
@@ -412,16 +436,14 @@ class Neo4jQueryReadStrategy(
   private def filterRelationship(sourceNode: Node, targetNode: Node, relationship: Relationship) = {
     val matchQuery = Cypher.`match`(sourceNode).`match`(targetNode).`match`(relationship)
 
-    def getContainer(filter: Filter): PropertyContainer = {
-      if (filter.isAttribute(Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS)) {
-        sourceNode
-      } else if (filter.isAttribute(Neo4jUtil.RELATIONSHIP_TARGET_ALIAS)) {
-        targetNode
-      } else if (filter.isAttribute(Neo4jUtil.RELATIONSHIP_ALIAS)) {
-        relationship
-      } else {
-        throw new IllegalArgumentException(s"Attribute '${filter.getAttribute.get}' is not valid")
-      }
+    def getAlias(filter: Filter): String = relationshipAliases
+      .find(filter.hasEntityAlias)
+      .getOrElse(throw new IllegalArgumentException(s"Attribute '${filter.getAttribute.get}' is not valid"))
+
+    def getContainer(alias: String): PropertyContainer = alias match {
+      case Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS => sourceNode
+      case Neo4jUtil.RELATIONSHIP_TARGET_ALIAS => targetNode
+      case _                                   => relationship
     }
 
     if (filters.nonEmpty) {
@@ -430,7 +452,8 @@ class Neo4jQueryReadStrategy(
           case and: And => mapFilter(and.left).and(mapFilter(and.right))
           case or: Or   => mapFilter(or.left).or(mapFilter(or.right))
           case filter: Filter =>
-            Neo4jUtil.mapSparkFiltersToCypher(filter, getContainer(filter), filter.getAttributeWithoutEntityName)
+            val alias = getAlias(filter)
+            Neo4jUtil.mapSparkFiltersToCypher(filter, getContainer(alias), Some(alias))
         }
       }
 
@@ -441,10 +464,23 @@ class Neo4jQueryReadStrategy(
     matchQuery
   }
 
-  private def getCorrectProperty(column: String, entity: PropertyContainer): Expression = {
+  /**
+   * Builds the projection for a required column.
+   *
+   * `alias` must be set only when the column is prefixed with the alias of the entity it belongs
+   * to, as it happens for relationship reads: node, query and GDS columns carry no alias, so a dot
+   * there is part of the property name and must be kept.
+   */
+  private def getCorrectProperty(
+    column: String,
+    entity: PropertyContainer,
+    alias: Option[String] = None
+  ): Expression = {
     def propertyOrSymbolicName(col: String) = {
       if (entity != null) entity.property(col) else Cypher.name(col)
     }
+
+    def withoutAlias(col: String) = alias.map(col.removeEntityAlias).getOrElse(col.unquote())
 
     column match {
       case Neo4jUtil.INTERNAL_ID_FIELD => Cypher.elementId(entity.asInstanceOf[Node]).as(Neo4jUtil.INTERNAL_ID_FIELD)
@@ -464,12 +500,10 @@ class Neo4jQueryReadStrategy(
         Cypher.labels(entity.asInstanceOf[Node]).as(Neo4jUtil.INTERNAL_REL_TARGET_LABELS_FIELD)
       case "*" => Asterisk.INSTANCE
       case name => {
-        val cleanedName = name.removeAlias()
         aggregateColumns.find(_.toString == name)
           .map {
             case count: Count => {
-              val col = count.column().describe().unquote().removeAlias()
-              val prop = propertyOrSymbolicName(col)
+              val prop = propertyOrSymbolicName(withoutAlias(count.column().describe()))
               if (count.isDistinct) {
                 Cypher.countDistinct(prop).as(name)
               } else {
@@ -477,17 +511,10 @@ class Neo4jQueryReadStrategy(
               }
             }
             case countStar: CountStar => Cypher.count(Asterisk.INSTANCE).as(name)
-            case max: Max =>
-              val col = max.column().describe().unquote().removeAlias()
-              val prop = propertyOrSymbolicName(col)
-              Cypher.max(prop).as(name)
-            case min: Min =>
-              val col = min.column().describe().unquote().removeAlias()
-              val prop = propertyOrSymbolicName(col)
-              Cypher.min(prop).as(name)
+            case max: Max => Cypher.max(propertyOrSymbolicName(withoutAlias(max.column().describe()))).as(name)
+            case min: Min => Cypher.min(propertyOrSymbolicName(withoutAlias(min.column().describe()))).as(name)
             case sum: Sum => {
-              val col = sum.column().describe().unquote().removeAlias()
-              val prop = propertyOrSymbolicName(col)
+              val prop = propertyOrSymbolicName(withoutAlias(sum.column().describe()))
               if (sum.isDistinct) {
                 Cypher.sumDistinct(prop).as(name)
               } else {
@@ -495,7 +522,7 @@ class Neo4jQueryReadStrategy(
               }
             }
           }
-          .getOrElse(propertyOrSymbolicName(cleanedName).as(name))
+          .getOrElse(propertyOrSymbolicName(withoutAlias(name)).as(name))
           .asInstanceOf[Expression]
       }
     }

--- a/src/main/scala/org/neo4j/spark/util/Neo4jImplicits.scala
+++ b/src/main/scala/org/neo4j/spark/util/Neo4jImplicits.scala
@@ -46,6 +46,12 @@ import javax.lang.model.SourceVersion
 
 object Neo4jImplicits {
 
+  /**
+   * Matches one segment of a property path: either a backtick quoted name,
+   * which can contain dots, or a run of characters up to the next dot.
+   */
+  private val PATH_SEGMENT = """`([^`]*)`|([^.`]+)""".r
+
   implicit class CypherImplicits(str: String) {
     private def isValidCypherIdentifier() = SourceVersion.isIdentifier(str) && !str.trim.startsWith("$")
 
@@ -55,15 +61,48 @@ object Neo4jImplicits {
 
     def isQuoted(): Boolean = str.startsWith("`");
 
-    def removeAlias(): String = {
-      val splatString = str.unquote().split('.')
+    /**
+     * Splits a, possibly backtick quoted, property path into its segments.
+     *
+     * Dots inside backticks belong to the property name, so `` `table.key` `` is a single property
+     * named `table.key`, while `location.x` is the `x` field of the `location` property.
+     */
+    def propertyPath(): Seq[String] = {
+      val segments = PATH_SEGMENT.findAllMatchIn(str)
+        .map(m => Option(m.group(1)).getOrElse(m.group(2)))
+        .toSeq
 
-      if (splatString.size > 1) {
-        splatString.tail.mkString(".")
-      } else {
-        str
+      if (segments.isEmpty) Seq(str) else segments
+    }
+
+    /**
+     * Removes the given entity alias (`source`, `target` or `rel`) from the head of the property
+     * path, leaving the rest of the path untouched.
+     *
+     * Only the alias is removed, not everything up to the first dot: `source.table.key` is the
+     * `table.key` property of the `source` node, not the `key` field of its `table` property.
+     */
+    def propertyPathWithoutAlias(alias: String): Seq[String] = {
+      val path = str.propertyPath()
+      val prefix = s"$alias."
+
+      path.head match {
+        case head if head.startsWith(prefix) => head.substring(prefix.length) +: path.tail
+        case `alias` if path.size > 1        => path.tail
+        case _                               => path
       }
     }
+
+    def hasEntityAlias(alias: String): Boolean = {
+      val path = str.propertyPath()
+
+      path.head.startsWith(s"$alias.") || (path.head == alias && path.size > 1)
+    }
+
+    /**
+     * Same as [[propertyPathWithoutAlias]], for the callers that need the path back as a string.
+     */
+    def removeEntityAlias(alias: String): String = str.propertyPathWithoutAlias(alias).mkString(".")
 
     /**
      * df: we need this to handle scenarios like `WHERE age > 19 and age < 22`,
@@ -184,8 +223,13 @@ object Neo4jImplicits {
       }
     }
 
+    /**
+     * Spark keeps the field names of a reference separate, so it already knows whether `a.b` is a
+     * property literally named `a.b` or the `b` field of the `a` property. Quoting each field name
+     * preserves that information once the reference is flattened into a single string.
+     */
     def rawAttributeName(): String = {
-      predicate.references().head.fieldNames().mkString(".")
+      predicate.references().head.fieldNames().map(_.quote()).mkString(".")
     }
 
     def rawLiteralValue(options: Neo4jOptions): Option[Value] = {
@@ -246,12 +290,7 @@ object Neo4jImplicits {
       case _                           => null
     })
 
-    def isAttribute(entityType: String): Boolean = {
-      getAttribute.exists(_.contains(s"$entityType."))
-    }
-
-    def getAttributeWithoutEntityName: Option[String] =
-      filter.getAttribute.map(_.unquote().split('.').tail.mkString("."))
+    def hasEntityAlias(alias: String): Boolean = getAttribute.exists(_.hasEntityAlias(alias))
 
     /**
      * df: we are not handling AND/OR because they are not actually filters

--- a/src/main/scala/org/neo4j/spark/util/Neo4jUtil.scala
+++ b/src/main/scala/org/neo4j/spark/util/Neo4jUtil.scala
@@ -132,8 +132,22 @@ object Neo4jUtil {
     .map(_ => "databricks")
     .getOrElse("spark")
 
-  def getCorrectProperty(container: PropertyContainer, attribute: String): Property = {
-    container.property(attribute.split('.'): _*)
+  /**
+   * Builds the property access for a Spark attribute.
+   *
+   * `entityAlias` must be set when the attribute is prefixed with the alias of the container
+   * (`source`, `target` or `rel`), as it happens for relationship reads.
+   */
+  def getCorrectProperty(
+    container: PropertyContainer,
+    attribute: String,
+    entityAlias: Option[String] = None
+  ): Property = {
+    val path = entityAlias
+      .map(attribute.propertyPathWithoutAlias)
+      .getOrElse(attribute.propertyPath())
+
+    container.property(path: _*)
   }
 
   def paramsFromFilters(filters: Array[Filter]): Map[String, Any] = {
@@ -163,44 +177,37 @@ object Neo4jUtil {
   def mapSparkFiltersToCypher(
     filter: Filter,
     container: PropertyContainer,
-    attributeAlias: Option[String] = None
+    entityAlias: Option[String] = None
   ): Condition = {
+    def property(attribute: String): Property = getCorrectProperty(container, attribute, entityAlias)
+
     filter match {
       case eqns: EqualNullSafe =>
         val parameter = valueToCypherExpression(eqns.attribute, eqns.value)
-        val property = getCorrectProperty(container, attributeAlias.getOrElse(eqns.attribute))
-        property.isNull.and(parameter.isNull)
-          .or(property.isEqualTo(parameter))
+        val prop = property(eqns.attribute)
+        prop.isNull.and(parameter.isNull)
+          .or(prop.isEqualTo(parameter))
       case eq: EqualTo =>
-        getCorrectProperty(container, attributeAlias.getOrElse(eq.attribute))
-          .isEqualTo(valueToCypherExpression(eq.attribute, eq.value))
+        property(eq.attribute).isEqualTo(valueToCypherExpression(eq.attribute, eq.value))
       case gt: GreaterThan =>
-        getCorrectProperty(container, attributeAlias.getOrElse(gt.attribute))
-          .gt(valueToCypherExpression(gt.attribute, gt.value))
+        property(gt.attribute).gt(valueToCypherExpression(gt.attribute, gt.value))
       case gte: GreaterThanOrEqual =>
-        getCorrectProperty(container, attributeAlias.getOrElse(gte.attribute))
-          .gte(valueToCypherExpression(gte.attribute, gte.value))
+        property(gte.attribute).gte(valueToCypherExpression(gte.attribute, gte.value))
       case lt: LessThan =>
-        getCorrectProperty(container, attributeAlias.getOrElse(lt.attribute))
-          .lt(valueToCypherExpression(lt.attribute, lt.value))
+        property(lt.attribute).lt(valueToCypherExpression(lt.attribute, lt.value))
       case lte: LessThanOrEqual =>
-        getCorrectProperty(container, attributeAlias.getOrElse(lte.attribute))
-          .lte(valueToCypherExpression(lte.attribute, lte.value))
+        property(lte.attribute).lte(valueToCypherExpression(lte.attribute, lte.value))
       case in: In =>
-        getCorrectProperty(container, attributeAlias.getOrElse(in.attribute))
-          .in(valueToCypherExpression(in.attribute, in.values))
+        property(in.attribute).in(valueToCypherExpression(in.attribute, in.values))
       case startWith: StringStartsWith =>
-        getCorrectProperty(container, attributeAlias.getOrElse(startWith.attribute))
-          .startsWith(valueToCypherExpression(startWith.attribute, startWith.value))
+        property(startWith.attribute).startsWith(valueToCypherExpression(startWith.attribute, startWith.value))
       case endsWith: StringEndsWith =>
-        getCorrectProperty(container, attributeAlias.getOrElse(endsWith.attribute))
-          .endsWith(valueToCypherExpression(endsWith.attribute, endsWith.value))
+        property(endsWith.attribute).endsWith(valueToCypherExpression(endsWith.attribute, endsWith.value))
       case contains: StringContains =>
-        getCorrectProperty(container, attributeAlias.getOrElse(contains.attribute))
-          .contains(valueToCypherExpression(contains.attribute, contains.value))
-      case notNull: IsNotNull => getCorrectProperty(container, attributeAlias.getOrElse(notNull.attribute)).isNotNull
-      case isNull: IsNull     => getCorrectProperty(container, attributeAlias.getOrElse(isNull.attribute)).isNull
-      case not: Not           => mapSparkFiltersToCypher(not.child, container, attributeAlias).not()
+        property(contains.attribute).contains(valueToCypherExpression(contains.attribute, contains.value))
+      case notNull: IsNotNull => property(notNull.attribute).isNotNull
+      case isNull: IsNull     => property(isNull.attribute).isNull
+      case not: Not           => mapSparkFiltersToCypher(not.child, container, entityAlias).not()
       case _: AlwaysTrue      => Cypher.literalTrue().asCondition()
       case _: AlwaysFalse     => Cypher.literalFalse().asCondition()
       case unsupported =>

--- a/src/test/scala/org/neo4j/spark/ReadIT.scala
+++ b/src/test/scala/org/neo4j/spark/ReadIT.scala
@@ -1172,6 +1172,43 @@ class ReadIT {
 
       assertThat(df.count()).isEqualTo(10)
     }
+
+    @Test
+    def reads_repacked_map(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
+      driver.executableQuery("CREATE (m:Map {`table.key`: 'value', `a.b.c`: 'nested value', plain: 'plain value'})")
+        .execute()
+
+      val df = spark.read.format(classOf[DataSource].getName)
+        .option("labels", "Map")
+        .load()
+
+      val rows = df.collect()
+
+      assertThat(rows).hasSize(1)
+      assertThat(rows.head.getAs[String]("table.key")).isEqualTo("value")
+      assertThat(rows.head.getAs[String]("a.b.c")).isEqualTo("nested value")
+      assertThat(rows.head.getAs[String]("plain")).isEqualTo("plain value")
+    }
+
+    @Test
+    def filters_on_repacked_map(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
+      driver.executableQuery(
+        """CREATE (:Map {`table.key`: 'value', `a.b.c`: 'nested value'})
+          |CREATE (:Map {`table.key`: 'another value', `a.b.c`: 'another nested value'})""".stripMargin
+      ).execute()
+
+      val df = spark.read.format(classOf[DataSource].getName)
+        .option("labels", "Map")
+        .load()
+        .select("`table.key`")
+        .where("`a.b.c` = 'nested value'")
+
+      val rows = df.collect()
+
+      assertThat(rows).hasSize(1)
+      assertThat(rows.head.getAs[String]("table.key")).isEqualTo("value")
+    }
+
   }
 
   @Nested
@@ -1580,12 +1617,79 @@ class ReadIT {
       assertThat(row.getAs[Long]("total")).isEqualTo(11L)
     }
 
+    @Test
+    def reads_repacked_map(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
+      driver.executableQuery(
+        """CREATE (s:MapSource {`table.key`: 'source value', `a.b.c`: 'source nested value'})
+          |CREATE (t:MapTarget {`table.key`: 'target value', `a.b.c`: 'target nested value'})
+          |CREATE (s)-[:MAPS {`table.key`: 'rel value', `a.b.c`: 'rel nested value'}]->(t)""".stripMargin
+      ).execute()
+
+      val df = spark.read.format(classOf[DataSource].getName)
+        .option("relationship.source.labels", "MapSource")
+        .option("relationship", "MAPS")
+        .option("relationship.target.labels", "MapTarget")
+        .load()
+
+      val rows = df.collect()
+
+      assertThat(rows).hasSize(1)
+      val row = rows.head
+      assertThat(row.getAs[String]("source.table.key")).isEqualTo("source value")
+      assertThat(row.getAs[String]("source.a.b.c")).isEqualTo("source nested value")
+      assertThat(row.getAs[String]("target.table.key")).isEqualTo("target value")
+      assertThat(row.getAs[String]("target.a.b.c")).isEqualTo("target nested value")
+      assertThat(row.getAs[String]("rel.table.key")).isEqualTo("rel value")
+      assertThat(row.getAs[String]("rel.a.b.c")).isEqualTo("rel nested value")
+    }
+
+    @Test
+    def filters_on_repacked_map(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
+      driver.executableQuery(
+        """CREATE (s:MapSource {`table.key`: 'source value', `a.b.c`: 'source nested value'})
+          |CREATE (t:MapTarget {`table.key`: 'target value'})
+          |CREATE (s)-[:MAPS {`table.key`: 'rel value'}]->(t)
+          |CREATE (s2:MapSource {`table.key`: 'another source value', `a.b.c`: 'another nested value'})
+          |CREATE (t2:MapTarget {`table.key`: 'another target value'})
+          |CREATE (s2)-[:MAPS {`table.key`: 'another rel value'}]->(t2)""".stripMargin
+      ).execute()
+
+      val df = spark.read.format(classOf[DataSource].getName)
+        .option("relationship.source.labels", "MapSource")
+        .option("relationship", "MAPS")
+        .option("relationship.target.labels", "MapTarget")
+        .load()
+        .select("`rel.table.key`", "`target.table.key`")
+        .where("`source.a.b.c` = 'source nested value'")
+
+      val rows = df.collect()
+
+      assertThat(rows).hasSize(1)
+      assertThat(rows.head.getAs[String]("rel.table.key")).isEqualTo("rel value")
+      assertThat(rows.head.getAs[String]("target.table.key")).isEqualTo("target value")
+    }
+
   }
 
   @Nested
   @DisplayName("by query")
   @Execution(ExecutionMode.SAME_THREAD)
   class ByQuery {
+
+    @Test
+    def reads_repacked_map(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
+      driver.executableQuery("CREATE (m:Map {`table.key`: 'value', `a.b.c`: 'nested value'})").execute()
+
+      val df = spark.read.format(classOf[DataSource].getName)
+        .option("query", "MATCH (m:Map) RETURN m.`table.key` AS `table.key`, m.`a.b.c` AS `a.b.c`")
+        .load()
+
+      val rows = df.collect()
+
+      assertThat(rows).hasSize(1)
+      assertThat(rows.head.getAs[String]("table.key")).isEqualTo("value")
+      assertThat(rows.head.getAs[String]("a.b.c")).isEqualTo("nested value")
+    }
 
     @Test
     def supports_returning_lists(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {

--- a/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
+++ b/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
@@ -178,6 +178,107 @@ class Neo4jQueryServiceTest {
 
     @ParameterizedTest
     @MethodSource(Array("versions_and_prefixes"))
+    def labels_when_the_selected_columns_contain_dots(
+      neo4j: Neo4j,
+      customCypherVersion: String,
+      prefix: String
+    ): Unit = {
+      val neo4jOptions = new Neo4jOptions(Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        QueryType.LABELS.toString.toLowerCase -> "Person",
+        Neo4jOptions.CYPHER_VERSION -> customCypherVersion
+      ))
+
+      val query: String = new Neo4jQueryService(
+        neo4jOptions,
+        new Neo4jQueryReadStrategy(
+          neo4j,
+          new CypherRenderer(neo4j, neo4jOptions),
+          new QueryEmbedder(),
+          Array.empty[Filter],
+          PartitionPagination.EMPTY,
+          List("table.key", "a.b.c")
+        )
+      ).createQuery()
+
+      assertThat(query).isEqualTo(
+        s"${prefix}MATCH (n:`Person`) RETURN n.`table.key` AS `table.key`, n.`a.b.c` AS `a.b.c`"
+      )
+    }
+
+    @ParameterizedTest
+    @MethodSource(Array("versions_and_prefixes"))
+    def labels_when_filtering_on_a_column_whose_name_contains_dots(
+      neo4j: Neo4j,
+      customCypherVersion: String,
+      prefix: String
+    ): Unit = {
+      val neo4jOptions = new Neo4jOptions(Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        QueryType.LABELS.toString.toLowerCase -> "Person",
+        Neo4jOptions.CYPHER_VERSION -> customCypherVersion
+      ))
+
+      val filters: Array[Filter] = Array[Filter](
+        EqualTo("`table.key`", "value"),
+        EqualTo("`a.b.c`", "value")
+      )
+
+      val query: String =
+        new Neo4jQueryService(
+          neo4jOptions,
+          new Neo4jQueryReadStrategy(
+            neo4j,
+            new CypherRenderer(neo4j, neo4jOptions),
+            new QueryEmbedder(),
+            filters
+          )
+        ).createQuery()
+
+      val tableKeyParam = "$" + "`table.key`".toParameterName("value")
+      val abcParam = "$" + "`a.b.c`".toParameterName("value")
+
+      assertThat(query).isEqualTo(
+        s"${prefix}MATCH (n:`Person`) " +
+          s"WHERE (n.`table.key` = $tableKeyParam AND n.`a.b.c` = $abcParam) RETURN n"
+      )
+    }
+
+    @ParameterizedTest
+    @MethodSource(Array("versions_and_prefixes"))
+    def labels_when_filtering_on_a_nested_field(
+      neo4j: Neo4j,
+      customCypherVersion: String,
+      prefix: String
+    ): Unit = {
+      val neo4jOptions = new Neo4jOptions(Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        QueryType.LABELS.toString.toLowerCase -> "Person",
+        Neo4jOptions.CYPHER_VERSION -> customCypherVersion
+      ))
+
+      val filters: Array[Filter] = Array[Filter](
+        GreaterThan("location.x", 0)
+      )
+
+      val query: String =
+        new Neo4jQueryService(
+          neo4jOptions,
+          new Neo4jQueryReadStrategy(
+            neo4j,
+            new CypherRenderer(neo4j, neo4jOptions),
+            new QueryEmbedder(),
+            filters
+          )
+        ).createQuery()
+
+      val paramName = "$" + "location.x".toParameterName(0)
+
+      assertThat(query).isEqualTo(s"${prefix}MATCH (n:`Person`) WHERE n.location.x > $paramName RETURN n")
+    }
+
+    @ParameterizedTest
+    @MethodSource(Array("versions_and_prefixes"))
     def labels_when_internal_id_selected(
       neo4j: Neo4j,
       customCypherVersion: String,
@@ -421,6 +522,88 @@ class Neo4jQueryServiceTest {
         s"${prefix}MATCH (source:`Person`) " +
           "MATCH (target:`Person`) " +
           s"MATCH (source)-[rel:`KNOWS`]->(target) RETURN source.name AS `source.name`, elementId(source) AS `<source.elementId>`"
+      )
+    }
+
+    @ParameterizedTest
+    @MethodSource(Array("versions_and_prefixes"))
+    def relationship_when_the_selected_columns_contain_dots(
+      neo4j: Neo4j,
+      customCypherVersion: String,
+      prefix: String
+    ): Unit = {
+      val neo4jOptions = new Neo4jOptions(Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        "relationship" -> "KNOWS",
+        "relationship.nodes.map" -> "false",
+        "relationship.source.labels" -> "Person",
+        "relationship.target.labels" -> "Person",
+        Neo4jOptions.CYPHER_VERSION -> customCypherVersion
+      ))
+
+      val query: String = new Neo4jQueryService(
+        neo4jOptions,
+        new Neo4jQueryReadStrategy(
+          neo4j,
+          new CypherRenderer(neo4j, neo4jOptions),
+          new QueryEmbedder(),
+          Array.empty[Filter],
+          PartitionPagination.EMPTY,
+          List("source.table.key", "target.a.b.c", "rel.table.key")
+        )
+      ).createQuery()
+
+      assertThat(query).isEqualTo(
+        s"${prefix}MATCH (source:`Person`) " +
+          "MATCH (target:`Person`) " +
+          "MATCH (source)-[rel:`KNOWS`]->(target) " +
+          "RETURN source.`table.key` AS `source.table.key`, " +
+          "target.`a.b.c` AS `target.a.b.c`, " +
+          "rel.`table.key` AS `rel.table.key`"
+      )
+    }
+
+    @ParameterizedTest
+    @MethodSource(Array("versions_and_prefixes"))
+    def relationship_when_filtering_on_a_column_whose_name_contains_dots(
+      neo4j: Neo4j,
+      customCypherVersion: String,
+      prefix: String
+    ): Unit = {
+      val neo4jOptions = new Neo4jOptions(Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        "relationship" -> "KNOWS",
+        "relationship.nodes.map" -> "false",
+        "relationship.source.labels" -> "Person",
+        "relationship.target.labels" -> "Person",
+        Neo4jOptions.CYPHER_VERSION -> customCypherVersion
+      ))
+
+      val filters: Array[Filter] = Array[Filter](
+        EqualTo("`source.table.key`", "value"),
+        EqualTo("`rel.a.b.c`", "value")
+      )
+
+      val query: String =
+        new Neo4jQueryService(
+          neo4jOptions,
+          new Neo4jQueryReadStrategy(
+            neo4j,
+            new CypherRenderer(neo4j, neo4jOptions),
+            new QueryEmbedder(),
+            filters
+          )
+        ).createQuery()
+
+      val sourceParam = "$" + "`source.table.key`".toParameterName("value")
+      val relParam = "$" + "`rel.a.b.c`".toParameterName("value")
+
+      assertThat(query).isEqualTo(
+        s"${prefix}MATCH (source:`Person`) " +
+          "MATCH (target:`Person`) " +
+          "MATCH (source)-[rel:`KNOWS`]->(target) " +
+          s"WHERE (source.`table.key` = $sourceParam AND rel.`a.b.c` = $relParam) " +
+          "RETURN rel, source AS source, target AS target"
       )
     }
 
@@ -791,6 +974,76 @@ class Neo4jQueryServiceTest {
            | AND (target.age = ${parameterNames("target.age_1")} OR target.age = ${parameterNames("target.age_2")})
            | AND rel.score = ${parameterNames("rel.score")})
            | RETURN rel, source AS source, target AS target""".stripMargin.replaceAll("\n", "")
+      )
+    }
+
+    @ParameterizedTest
+    @MethodSource(Array("versions_and_prefixes"))
+    def labels_yields_aggregations_on_columns_whose_name_contains_dots(
+      neo4j: Neo4j,
+      customCypherVersion: String,
+      prefix: String
+    ): Unit = {
+      val neo4jOptions = new Neo4jOptions(Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        QueryType.LABELS.toString.toLowerCase -> "Person",
+        Neo4jOptions.CYPHER_VERSION -> customCypherVersion
+      ))
+
+      val nestedField = new DummyNamedReference("`a.b.c`")
+      val query: String = new Neo4jQueryService(
+        neo4jOptions,
+        new Neo4jQueryReadStrategy(
+          neo4j,
+          new CypherRenderer(neo4j, neo4jOptions),
+          new QueryEmbedder(),
+          Array.empty[Filter],
+          PartitionPagination.EMPTY,
+          Seq("table.key", "MAX(`a.b.c`)"),
+          Array(new Max(nestedField))
+        )
+      ).createQuery()
+
+      assertThat(query).isEqualTo(
+        s"${prefix}MATCH (n:`Person`) RETURN n.`table.key` AS `table.key`, max(n.`a.b.c`) AS `MAX(``a.b.c``)`"
+      )
+    }
+
+    @ParameterizedTest
+    @MethodSource(Array("versions_and_prefixes"))
+    def relationship_yields_aggregations_on_columns_whose_name_contains_dots(
+      neo4j: Neo4j,
+      customCypherVersion: String,
+      prefix: String
+    ): Unit = {
+      val neo4jOptions = new Neo4jOptions(Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        "relationship" -> "BOUGHT",
+        "relationship.nodes.map" -> "false",
+        "relationship.source.labels" -> "Person",
+        "relationship.target.labels" -> "Product",
+        Neo4jOptions.CYPHER_VERSION -> customCypherVersion
+      ))
+
+      val nestedField = new DummyNamedReference("`target.a.b.c`")
+      val query: String = new Neo4jQueryService(
+        neo4jOptions,
+        new Neo4jQueryReadStrategy(
+          neo4j,
+          new CypherRenderer(neo4j, neo4jOptions),
+          new QueryEmbedder(),
+          Array.empty[Filter],
+          PartitionPagination.EMPTY,
+          Seq("source.table.key", "SUM(`target.a.b.c`)"),
+          Array(new Sum(nestedField, false))
+        )
+      ).createQuery()
+
+      assertThat(query).isEqualTo(
+        s"${prefix}MATCH (source:`Person`) " +
+          "MATCH (target:`Product`) " +
+          "MATCH (source)-[rel:`BOUGHT`]->(target) " +
+          "RETURN source.`table.key` AS `source.table.key`, sum(target.`a.b.c`) AS `SUM(``target.a.b.c``)`"
       )
     }
 

--- a/src/test/scala/org/neo4j/spark/util/Neo4jImplicitsTest.scala
+++ b/src/test/scala/org/neo4j/spark/util/Neo4jImplicitsTest.scala
@@ -102,12 +102,52 @@ class Neo4jImplicitsTest {
     }
 
     @Test
-    def returns_the_attribute_without_the_entity_identifier(): Unit = {
-      val filter = EqualTo("person.address.coords", 32)
+    def detects_the_entity_alias(): Unit = {
+      assertTrue(EqualTo("source.name", "John").hasEntityAlias("source"))
+      assertTrue(EqualTo("`source.name`", "John").hasEntityAlias("source"))
+      assertTrue(EqualTo("`source.table.key`", "John").hasEntityAlias("source"))
+      assertTrue(EqualTo("`rel.since`", 32).hasEntityAlias("rel"))
+    }
 
-      val attribute = filter.getAttributeWithoutEntityName
+    @Test
+    def does_not_detect_an_entity_alias_when_it_is_only_part_of_the_property_name(): Unit = {
+      assertFalse(EqualTo("`mysource.name`", "John").hasEntityAlias("source"))
+      assertFalse(EqualTo("`name.source.x`", "John").hasEntityAlias("source"))
+      assertFalse(EqualTo("source", "John").hasEntityAlias("source"))
+    }
+  }
 
-      assertThat(attribute.get).isEqualTo("address.coords")
+  @Nested
+  class PropertyPaths {
+
+    @Test
+    def splits_a_nested_property_access(): Unit = {
+      assertThat("location.x".propertyPath().asJava).containsExactly("location", "x")
+    }
+
+    @Test
+    def keeps_a_quoted_property_name_as_a_single_segment(): Unit = {
+      assertThat("`table.key`".propertyPath().asJava).containsExactly("table.key")
+      assertThat("`a.b.c`".propertyPath().asJava).containsExactly("a.b.c")
+    }
+
+    @Test
+    def splits_a_nested_access_on_a_quoted_property_name(): Unit = {
+      assertThat("`table.key`.x".propertyPath().asJava).containsExactly("table.key", "x")
+    }
+
+    @Test
+    def removes_the_entity_alias_keeping_the_dots_of_the_property_name(): Unit = {
+      assertThat("`source.table.key`".removeEntityAlias("source")).isEqualTo("table.key")
+      assertThat("`source.a.b.c`".removeEntityAlias("source")).isEqualTo("a.b.c")
+      assertThat("source.name".removeEntityAlias("source")).isEqualTo("name")
+      assertThat("`source.location`.x".removeEntityAlias("source")).isEqualTo("location.x")
+    }
+
+    @Test
+    def leaves_the_property_untouched_when_it_is_not_prefixed_with_the_alias(): Unit = {
+      assertThat("`table.key`".removeEntityAlias("source")).isEqualTo("table.key")
+      assertThat("`mysource.key`".removeEntityAlias("source")).isEqualTo("mysource.key")
     }
   }
 


### PR DESCRIPTION
This bug is related to all properties containing dot, not only packaged map structs. 

The existing implementation treats dot primarily as separator between an alias and a property, and strips it when reading. For example flattened map property `mymap.myproperty` becomes `myproperty` and thus always read as null. 

In reality, the dot has 3 possible meanings: 
* an alias
* part of the property 
* nested field access (for example in `points`). 

This PR addresses this ambiguity. It makes alias stripping explicit and requires the exact alias name, where possible. Filter encoding also uses extra backticks to distinguish between property name and field access.   