### PR TITLE
fix: security warnings wrt encryption settings

### DIFF
--- a/common/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
@@ -507,7 +507,7 @@ case class Neo4jDriverOptions(
         if (!encryption) {
           logWarning(
             s"Connecting to ${primaryUrl.getScheme}://${primaryUrl.getHost} without any encryption! " +
-              s"Credentials will be sent in cleartext. To start encrypting, use an encrypted scheme (e.g. neo4j+s://)."
+              s"Credentials will be sent in cleartext. To start encrypting, use an encrypted scheme (such as 'neo4j+s://')."
           )
 
           builder.withoutEncryption()

--- a/common/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
@@ -507,8 +507,7 @@ case class Neo4jDriverOptions(
         if (!encryption) {
           logWarning(
             s"Connecting to ${primaryUrl.getScheme}://${primaryUrl.getHost} without any encryption! " +
-              s"Credentials will be sent in cleartext. To start encrypting, use a '+s' scheme (e.g. neo4j+s://) or set " +
-              s"connector option 'encryption.enabled' to true."
+              s"Credentials will be sent in cleartext. To start encrypting, use an encrypted scheme (e.g. neo4j+s://)."
           )
 
           builder.withoutEncryption()

--- a/common/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
@@ -518,7 +518,14 @@ case class Neo4jDriverOptions(
         trustStrategy
           .map(Config.TrustStrategy.Strategy.valueOf)
           .map {
-            case TrustStrategy.Strategy.TRUST_ALL_CERTIFICATES              => TrustStrategy.trustAllCertificates()
+            case TrustStrategy.Strategy.TRUST_ALL_CERTIFICATES =>
+              if (encryption) { // no encryption -> no handshake -> no need for log
+                logWarning(
+                  "TRUST_ALL_CERTIFICATES disables server identity verification, making the connection " +
+                    "vulnerable to man-in-the-middle attacks. Do not use it in production."
+                )
+              }
+              TrustStrategy.trustAllCertificates()
             case TrustStrategy.Strategy.TRUST_SYSTEM_CA_SIGNED_CERTIFICATES => TrustStrategy.trustSystemCertificates()
             case TrustStrategy.Strategy.TRUST_CUSTOM_CA_SIGNED_CERTIFICATES =>
               TrustStrategy.trustCustomCertificateSignedBy(new File(certificatePath))

--- a/common/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
@@ -481,7 +481,7 @@ case class Neo4jDriverOptions(
   acquisitionTimeout: Int,
   livenessCheckTimeout: Int,
   connectionTimeout: Int
-) extends Serializable {
+) extends Serializable with Logging {
 
   def createDriver(): Driver = {
     val (url, _) = connectionUrls
@@ -505,6 +505,12 @@ case class Neo4jDriverOptions(
       case "neo4j+s" | "neo4j+ssc" | "bolt+s" | "bolt+ssc" => ()
       case _ => {
         if (!encryption) {
+          logWarning(
+            s"Connecting to ${primaryUrl.getScheme}://${primaryUrl.getHost} without any encryption! " +
+              s"Credentials will be sent in cleartext. To start encrypting, use a '+s' scheme (e.g. neo4j+s://) or set " +
+              s"connector option 'encryption.enabled' to true."
+          )
+
           builder.withoutEncryption()
         } else {
           builder.withEncryption()


### PR DESCRIPTION
Introduces two warnings:
- warn users who encrypt, but accepts all certificates
- warn users who connect without encryption