### PR TITLE
fix: replace quote function with Cypher DSL sanitizer

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -25,6 +25,10 @@
             <artifactId>neo4j-cypher-dsl</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.neo4j</groupId>
+            <artifactId>neo4j-cypher-dsl-schema-name-support</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.neo4j.connectors</groupId>
             <artifactId>commons-authn-spi</artifactId>
         </dependency>

--- a/common/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
+++ b/common/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
@@ -49,7 +49,7 @@ class Neo4jQueryWriteStrategy(private val neo4j: Neo4j, private val saveMode: Sa
   private def createPropsList(props: Map[String, String], prefix: String): String = {
     props
       .map(key => {
-        s"${key._2.quote()}: ${Neo4jQueryStrategy.VARIABLE_EVENT}.$prefix.${key._2.quote()}"
+        s"${key._2.sanitizeSchemaName()}: ${Neo4jQueryStrategy.VARIABLE_EVENT}.$prefix.${key._2.sanitizeSchemaName()}"
       }).mkString(", ")
   }
 
@@ -77,14 +77,14 @@ class Neo4jQueryWriteStrategy(private val neo4j: Neo4j, private val saveMode: Sa
     val sourceKeyword = keywordFromSaveMode(options.relationshipMetadata.sourceSaveMode)
     val targetKeyword = keywordFromSaveMode(options.relationshipMetadata.targetSaveMode)
 
-    val relationship = options.relationshipMetadata.relationshipType.quote()
+    val relationship = options.relationshipMetadata.relationshipType.sanitizeSchemaName()
 
     val sourceLabels = options.relationshipMetadata.source.labels
-      .map(_.quote())
+      .map(_.sanitizeSchemaName())
       .mkString(":")
 
     val targetLabels = options.relationshipMetadata.target.labels
-      .map(_.quote())
+      .map(_.sanitizeSchemaName())
       .mkString(":")
 
     val sourceKeys = createPropsList(
@@ -107,7 +107,7 @@ class Neo4jQueryWriteStrategy(private val neo4j: Neo4j, private val saveMode: Sa
     val relKeys = if (options.relationshipMetadata.relationshipKeys.nonEmpty) {
       options.relationshipMetadata.relationshipKeys
         .map(t =>
-          s"${t._2.quote()}: ${Neo4jQueryStrategy.VARIABLE_EVENT}.${Neo4jUtil.RELATIONSHIP_ALIAS}.${Neo4jWriteMappingStrategy.KEYS}.${t._1.quote()}"
+          s"${t._2.sanitizeSchemaName()}: ${Neo4jQueryStrategy.VARIABLE_EVENT}.${Neo4jUtil.RELATIONSHIP_ALIAS}.${Neo4jWriteMappingStrategy.KEYS}.${t._1.sanitizeSchemaName()}"
         )
         .mkString("{", ", ", "}")
     } else {
@@ -126,7 +126,7 @@ class Neo4jQueryWriteStrategy(private val neo4j: Neo4j, private val saveMode: Sa
     val keyword = keywordFromSaveMode(saveMode)
 
     val labels = options.nodeMetadata.labels
-      .map(_.quote())
+      .map(_.sanitizeSchemaName())
       .mkString(":")
 
     val keys = createPropsList(
@@ -244,7 +244,7 @@ class Neo4jQueryReadStrategy(
 
         if (entity != null && splatColumn.length == 1) {
           entity match {
-            case n: Node         => n.as(entityName.quote())
+            case n: Node         => n.as(entityName.sanitizeSchemaName())
             case r: Relationship => r.getRequiredSymbolicName
           }
         } else {

--- a/common/src/main/scala/org/neo4j/spark/service/SchemaService.scala
+++ b/common/src/main/scala/org/neo4j/spark/service/SchemaService.scala
@@ -91,7 +91,9 @@ class SchemaService(
         logResolutionChange("APOC is not installed. Switching to query schema resolution", e)
         // TODO get back to Cypher DSL when rand function will be available
         val query =
-          s"""${selectCypherVersionClause(neo4j)}MATCH (${Neo4jUtil.NODE_ALIAS}:${labels.map(_.quote()).mkString(":")})
+          s"""${selectCypherVersionClause(
+              neo4j
+            )}MATCH (${Neo4jUtil.NODE_ALIAS}:${labels.map(_.sanitizeSchemaName()).mkString(":")})
              |RETURN ${Neo4jUtil.NODE_ALIAS}
              |ORDER BY rand()
              |LIMIT ${options.schemaMetadata.flattenLimit}
@@ -245,10 +247,10 @@ class SchemaService(
           s"""${selectCypherVersionClause(
               neo4j
             )}MATCH (${Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS}:${options.relationshipMetadata.source.labels.map(
-              _.quote()
+              _.sanitizeSchemaName()
             ).mkString(":")})
              |MATCH (${Neo4jUtil.RELATIONSHIP_TARGET_ALIAS}:${options.relationshipMetadata.target.labels.map(
-              _.quote()
+              _.sanitizeSchemaName()
             ).mkString(":")})
              |MATCH (${Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS})-[${Neo4jUtil.RELATIONSHIP_ALIAS}:${options.relationshipMetadata.relationshipType}]->(${Neo4jUtil.RELATIONSHIP_TARGET_ALIAS})
              |RETURN ${Neo4jUtil.RELATIONSHIP_ALIAS}
@@ -317,7 +319,9 @@ class SchemaService(
       columns.map(StructField(_, DataTypes.StringType))
     } else {
       try {
-        columns.map(column => structFields.find(_.name.quote() == column.quote()).orNull).filter(_ != null)
+        columns.map(column =>
+          structFields.find(_.name.sanitizeSchemaName() == column.sanitizeSchemaName()).orNull
+        ).filter(_ != null)
       } catch {
         case _: Throwable => structFields.toArray
       }
@@ -424,7 +428,7 @@ class SchemaService(
   def countForNodeWithQuery(filters: Array[Filter]): Long = {
     val query = if (filters.isEmpty) {
       options.nodeMetadata.labels
-        .map(_.quote())
+        .map(_.sanitizeSchemaName())
         .map(label =>
           s"""
              |MATCH (:$label)
@@ -450,16 +454,16 @@ class SchemaService(
   def countForRelationshipWithQuery(filters: Array[Filter]): Long = {
     val query = if (filters.isEmpty) {
       val sourceQueries = options.relationshipMetadata.source.labels
-        .map(_.quote())
+        .map(_.sanitizeSchemaName())
         .map(label =>
-          s"""MATCH (:$label)-[${Neo4jUtil.RELATIONSHIP_ALIAS}:${options.relationshipMetadata.relationshipType.quote()}]->()
+          s"""MATCH (:$label)-[${Neo4jUtil.RELATIONSHIP_ALIAS}:${options.relationshipMetadata.relationshipType.sanitizeSchemaName()}]->()
              |RETURN count(${Neo4jUtil.RELATIONSHIP_ALIAS}) AS count
              |""".stripMargin
         )
       val targetQueries = options.relationshipMetadata.target.labels
-        .map(_.quote())
+        .map(_.sanitizeSchemaName())
         .map(label =>
-          s"""MATCH ()-[${Neo4jUtil.RELATIONSHIP_ALIAS}:${options.relationshipMetadata.relationshipType.quote()}]->(:$label)
+          s"""MATCH ()-[${Neo4jUtil.RELATIONSHIP_ALIAS}:${options.relationshipMetadata.relationshipType.sanitizeSchemaName()}]->(:$label)
              |RETURN count(${Neo4jUtil.RELATIONSHIP_ALIAS}) AS count
              |""".stripMargin
         )
@@ -667,9 +671,9 @@ class SchemaService(
       case OptimizationType.NONE => log.info("No optimization type provided")
       case _ => {
         try {
-          val quotedLabel = label.quote()
+          val quotedLabel = label.sanitizeSchemaName()
           val quotedProps = props
-            .map(prop => s"${Neo4jUtil.NODE_ALIAS}.${prop.quote()}")
+            .map(prop => s"${Neo4jUtil.NODE_ALIAS}.${prop.sanitizeSchemaName()}")
             .mkString(", ")
           val isNeo4j4 = neo4j.getVersion.getMajor == 4
           val uniqueFieldName = if (!isNeo4j4) "owningConstraint" else "uniqueness"
@@ -687,7 +691,7 @@ class SchemaService(
               )
             }
           }
-          val actionName = s"spark_${action.toString}_${label}_$dashSeparatedProps".quote()
+          val actionName = s"spark_${action.toString}_${label}_$dashSeparatedProps".sanitizeSchemaName()
           val queryPrefix = action match {
             case OptimizationType.INDEX            => s"CREATE INDEX $actionName"
             case OptimizationType.NODE_CONSTRAINTS => s"CREATE CONSTRAINT $actionName"
@@ -735,8 +739,8 @@ class SchemaService(
     }
     val dashSeparatedProps = keys.values.mkString("-")
     val constraintName =
-      s"spark_${entityType}_${constraintType.replace(s"$entityType ", "")}-CONSTRAINT_${entityIdentifier}_$dashSeparatedProps".quote()
-    val props = keys.values.map(_.quote()).map("e." + _).mkString(", ")
+      s"spark_${entityType}_${constraintType.replace(s"$entityType ", "")}-CONSTRAINT_${entityIdentifier}_$dashSeparatedProps".sanitizeSchemaName()
+    val props = keys.values.map(_.sanitizeSchemaName()).map("e." + _).mkString(", ")
     val asciiRepresentation: String = createCypherPattern(entityType, entityIdentifier)
     session.writeTransaction(
       tx => {
@@ -750,8 +754,8 @@ class SchemaService(
 
   private def createCypherPattern(entityType: String, entityIdentifier: String) = {
     val asciiRepresentation = entityType match {
-      case "NODE"         => s"(e:${entityIdentifier.quote()})"
-      case "RELATIONSHIP" => s"()-[e:${entityIdentifier.quote()}]->()"
+      case "NODE"         => s"(e:${entityIdentifier.sanitizeSchemaName()})"
+      case "RELATIONSHIP" => s"()-[e:${entityIdentifier.sanitizeSchemaName()}]->()"
       case _              => throw new IllegalArgumentException(s"$entityType not supported")
     }
     asciiRepresentation
@@ -775,18 +779,19 @@ class SchemaService(
           })
           .foreach(t => {
             val prop = t._1
-            val propQuoted = prop.quote()
+            val propQuoted = prop.sanitizeSchemaName()
             val cypherType = t._2
             val isNullable = t._3
             if (constraints.contains(SchemaConstraintsOptimizationType.TYPE)) {
-              val typeConstraintName = s"spark_$entityType-TYPE-CONSTRAINT-$entityIdentifier-$prop".quote()
+              val typeConstraintName = s"spark_$entityType-TYPE-CONSTRAINT-$entityIdentifier-$prop".sanitizeSchemaName()
               tx.run(
                 s"CREATE CONSTRAINT $typeConstraintName IF NOT EXISTS FOR $asciiRepresentation REQUIRE e.$propQuoted IS :: $cypherType"
               ).consume()
             }
             if (constraints.contains(SchemaConstraintsOptimizationType.EXISTS)) {
               if (!isNullable) {
-                val notNullConstraintName = s"spark_$entityType-NOT_NULL-CONSTRAINT-$entityIdentifier-$prop".quote()
+                val notNullConstraintName =
+                  s"spark_$entityType-NOT_NULL-CONSTRAINT-$entityIdentifier-$prop".sanitizeSchemaName()
                 tx.run(
                   s"CREATE CONSTRAINT $notNullConstraintName IF NOT EXISTS FOR $asciiRepresentation REQUIRE e.$propQuoted IS NOT NULL"
                 ).consume()
@@ -993,9 +998,9 @@ class SchemaService(
   }
 
   private def lastOffsetForRelationship(): Option[Long] = {
-    val sourceLabel = options.relationshipMetadata.source.labels.head.quote()
-    val targetLabel = options.relationshipMetadata.target.labels.head.quote()
-    val relType = options.relationshipMetadata.relationshipType.quote()
+    val sourceLabel = options.relationshipMetadata.source.labels.head.sanitizeSchemaName()
+    val targetLabel = options.relationshipMetadata.target.labels.head.sanitizeSchemaName()
+    val relType = options.relationshipMetadata.relationshipType.sanitizeSchemaName()
 
     session.run(
       s"""MATCH (s:$sourceLabel)-[r:$relType]->(t:$targetLabel)

--- a/common/src/main/scala/org/neo4j/spark/util/Neo4jImplicits.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Neo4jImplicits.scala
@@ -46,6 +46,7 @@ import org.apache.spark.sql.types.DataTypes
 import org.apache.spark.sql.types.MapType
 import org.apache.spark.sql.types.StructField
 import org.apache.spark.sql.types.StructType
+import org.neo4j.cypherdsl.support.schema_name.SchemaNames
 import org.neo4j.driver.Value
 import org.neo4j.driver.types.Entity
 import org.neo4j.driver.types.Node
@@ -56,18 +57,27 @@ import org.neo4j.spark.service.SchemaService
 
 import scala.collection.JavaConverters._
 
-import javax.lang.model.SourceVersion
-
 object Neo4jImplicits {
 
+  private val BACKTICK = "`"
+
   implicit class CypherImplicits(str: String) {
-    private def isValidCypherIdentifier() = SourceVersion.isIdentifier(str) && !str.trim.startsWith("$")
 
-    def quote(): String = if (!isValidCypherIdentifier() && !str.isQuoted()) s"`$str`" else str
+    def sanitizeSchemaName(): String = {
+      val sanitizeThis =
+        if (str.startsWith(BACKTICK) && str.endsWith(BACKTICK)) str.substring(1, str.length - 1) else str
 
-    def unquote(): String = str.replaceAll("`", "");
+      // 1) we target older JVMs and must therefore use CypherDSL 2022.
+      // 2) introducing CypherDSL sanitizer here is to resolve a security concern.
+      // because of (1) and (2), we don't get the fix for escaping names that begin with "$", introduced in version 2024
+      if (sanitizeThis.startsWith("$")) {
+        SchemaNames.sanitize(sanitizeThis, true).orElse("")
+      } else {
+        SchemaNames.sanitize(sanitizeThis).orElse("")
+      }
+    }
 
-    def isQuoted(): Boolean = str.startsWith("`");
+    def unquote(): String = str.replaceAll(BACKTICK, "")
 
     def removeAlias(): String = {
       val splatString = str.unquote().split('.')
@@ -93,7 +103,7 @@ object Neo4jImplicits {
 
       val base64ed = java.util.Base64.getEncoder.encodeToString(attributeValue.getBytes())
 
-      s"${base64ed}_${str.unquote()}".quote()
+      s"${base64ed}_${str.unquote()}".sanitizeSchemaName()
     }
   }
 

--- a/common/src/test/scala/org/neo4j/spark/util/Neo4jImplicitsTest.scala
+++ b/common/src/test/scala/org/neo4j/spark/util/Neo4jImplicitsTest.scala
@@ -30,62 +30,109 @@ import org.junit.Test
 import org.neo4j.spark.util.Neo4jImplicits._
 
 import scala.collection.JavaConverters.mapAsJavaMapConverter
-import scala.collection.JavaConverters.mapAsScalaMapConverter
 import scala.collection.JavaConverters.seqAsJavaListConverter
 import scala.collection.immutable.ListMap
 
 class Neo4jImplicitsTest {
 
   @Test
-  def `should quote the string` {
+  def `should quote the string`(): Unit = {
     // given
     val value = "Test with space"
 
     // when
-    val actual = value.quote
+    val actual = value.sanitizeSchemaName()
 
     // then
     assertEquals(s"`$value`", actual)
   }
 
   @Test
-  def `should quote text that starts with $` {
+  def `should quote text that starts with $`(): Unit = {
     // given
-    val value = "$tring"
+    val value = "$string"
 
     // when
-    val actual = value.quote
+    val actual = value.sanitizeSchemaName()
 
     // then
-    assertEquals(s"`$value`", actual)
+    assertEquals("`$string`", actual)
   }
 
   @Test
-  def `should not re-quote the string` {
+  def `should quote text that starts with $ even when quoted`(): Unit = {
+    // given
+    val value = "`$string`"
+
+    // when
+    val actual = value.sanitizeSchemaName()
+
+    // then
+    assertEquals("`$string`", actual)
+  }
+
+  @Test
+  def `should sanitize text that has backtick`(): Unit = {
+    // given
+    val value = "User can put back`ticks"
+
+    // when
+    val actual = value.sanitizeSchemaName()
+
+    // then
+    assertEquals("`User can put back``ticks`", actual)
+  }
+
+  @Test
+  def `should sanitize text that has backtick and no spaces`(): Unit = {
+    // given
+    val value = "Per`son"
+
+    // when
+    val actual = value.sanitizeSchemaName()
+
+    // then
+    assertEquals("`Per``son`", actual)
+  }
+
+  @Test
+  def `should not re-quote the string`(): Unit = {
     // given
     val value = "`Test with space`"
 
     // when
-    val actual = value.quote
+    val actual = value.sanitizeSchemaName()
 
     // then
     assertEquals(value, actual)
   }
 
   @Test
-  def `should not quote the string` {
+  def `should not re-quote the string even when sanitized`(): Unit = {
+    // given
+    val value = "`Test wi`th space`"
+
+    // when
+    val actual = value.sanitizeSchemaName()
+
+    // then
+    assertEquals(actual, "`Test wi``th space`")
+  }
+
+  @Test
+  def `should not quote the string`(): Unit = {
     // given
     val value = "Test"
 
     // when
-    val actual = value.quote
+    val actual = value.sanitizeSchemaName()
 
     // then
     assertEquals(value, actual)
   }
 
   @Test
-  def `should return attribute if filter has it` {
+  def `should return attribute if filter has it`(): Unit = {
     // given
     val filter = EqualTo("name", "John")
 
@@ -97,7 +144,7 @@ class Neo4jImplicitsTest {
   }
 
   @Test
-  def `should return an empty option if the filter doesn't have an attribute` {
+  def `should return an empty option if the filter doesn't have an attribute`(): Unit = {
     // given
     val filter = And(EqualTo("name", "John"), EqualTo("age", 32))
 
@@ -109,7 +156,7 @@ class Neo4jImplicitsTest {
   }
 
   @Test
-  def `should return the attribute without the entity identifier` {
+  def `should return the attribute without the entity identifier`(): Unit = {
     // given
     val filter = EqualTo("person.address.coords", 32)
 
@@ -121,7 +168,7 @@ class Neo4jImplicitsTest {
   }
 
   @Test
-  def `struct should return true if contains fields`: Unit = {
+  def `struct should return true if contains fields`(): Unit = {
     val struct = StructType(Seq(
       StructField("is_hero", DataTypes.BooleanType),
       StructField("name", DataTypes.StringType),
@@ -132,7 +179,7 @@ class Neo4jImplicitsTest {
   }
 
   @Test
-  def `struct should return false if not contains fields`: Unit = {
+  def `struct should return false if not contains fields`(): Unit = {
     val struct =
       StructType(Seq(StructField("is_hero", DataTypes.BooleanType), StructField("name", DataTypes.StringType)))
 
@@ -140,7 +187,7 @@ class Neo4jImplicitsTest {
   }
 
   @Test
-  def `getMissingFields should handle maps`: Unit = {
+  def `getMissingFields should handle maps`(): Unit = {
     val struct = StructType(Seq(
       StructField("im", DataTypes.StringType),
       StructField("im.a", DataTypes.createMapType(DataTypes.StringType, DataTypes.StringType)),
@@ -161,7 +208,7 @@ class Neo4jImplicitsTest {
   }
 
   @Test
-  def `groupByCols aggregation should work`: Unit = {
+  def `groupByCols aggregation should work`(): Unit = {
     val aggField = new NamedReference {
       override def fieldNames(): Array[String] = Array("foo")
 

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,11 @@
                 <version>${cypherdsl.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.neo4j</groupId>
+                <artifactId>neo4j-cypher-dsl-schema-name-support</artifactId>
+                <version>${cypherdsl.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.neo4j.connectors</groupId>
                 <artifactId>commons-authn-keycloak</artifactId>
                 <version>${connectors-commons.version}</version>


### PR DESCRIPTION
The naive quotation function did not cover nested backticks. Which
makes it problematic to introduce property names, labels, rel types,
constraint names etc that has backticks in them.

By using Cypher DSL we introduce a more robust mechanic for escaping
identifier names.

Just using Cypher DSL v2022 creates regressions around two areas:
 - Sanitize values that is already quoted e.g. "`test`"
 - Sanitize values that start with "$" e.g. "$string"

Implemented in such way where these quirks are retained to keep
backwards compatibility.