### PR TITLE
fix: resolve an ambiguity between alias separation and dots in property names for 5.0

### DIFF
--- a/common/src/main/scala/org/neo4j/spark/service/MappingService.scala
+++ b/common/src/main/scala/org/neo4j/spark/service/MappingService.scala
@@ -77,18 +77,18 @@ class Neo4jWriteMappingStrategy(private val options: Neo4jOptions)
 
     override def accept(key: String, value: AnyRef): Unit = {
       if (key.startsWith(Neo4jUtil.RELATIONSHIP_ALIAS.concat("."))) {
-        relMap.get(PROPERTIES).put(key.removeAlias(), value)
+        relMap.get(PROPERTIES).put(key.removeEntityAlias(Neo4jUtil.RELATIONSHIP_ALIAS), value)
       } else if (key.startsWith(Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS.concat("."))) {
         if (options.relationshipMetadata.source.nodeKeys.contains(key)) {
-          sourceNodeMap.get(KEYS).put(key.removeAlias(), value)
+          sourceNodeMap.get(KEYS).put(key.removeEntityAlias(Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS), value)
         } else {
-          sourceNodeMap.get(PROPERTIES).put(key.removeAlias(), value)
+          sourceNodeMap.get(PROPERTIES).put(key.removeEntityAlias(Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS), value)
         }
       } else if (key.startsWith(Neo4jUtil.RELATIONSHIP_TARGET_ALIAS.concat("."))) {
         if (options.relationshipMetadata.target.nodeKeys.contains(key)) {
-          targetNodeMap.get(KEYS).put(key.removeAlias(), value)
+          targetNodeMap.get(KEYS).put(key.removeEntityAlias(Neo4jUtil.RELATIONSHIP_TARGET_ALIAS), value)
         } else {
-          targetNodeMap.get(PROPERTIES).put(key.removeAlias(), value)
+          targetNodeMap.get(PROPERTIES).put(key.removeEntityAlias(Neo4jUtil.RELATIONSHIP_TARGET_ALIAS), value)
         }
       }
     }

--- a/common/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
+++ b/common/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
@@ -196,25 +196,19 @@ class Neo4jQueryReadStrategy(
   private def convertSort(entity: PropertyContainer, order: SortOrder): SortItem = {
     val sortExpression = order.expression().describe()
 
-    val container: Option[PropertyContainer] = entity match {
-      case relationship: Relationship =>
-        if (sortExpression.contains(s"${Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS}.")) {
-          Some(relationship.getLeft)
-        } else if (sortExpression.contains(s"${Neo4jUtil.RELATIONSHIP_TARGET_ALIAS}.")) {
-          Some(relationship.getRight)
-        } else if (sortExpression.contains(s"${Neo4jUtil.RELATIONSHIP_ALIAS}.")) {
-          Some(relationship)
-        } else {
-          None
-        }
-      case _ => Some(entity)
+    val container: Option[(PropertyContainer, Option[String])] = entity match {
+      case relationship: Relationship => entityAlias(sortExpression)
+          .map(alias => (relationshipContainer(alias, relationship), Some(alias)))
+      case _ => Some((entity, None))
     }
     val direction =
       if (order.direction() == SortDirection.ASCENDING) SortItem.Direction.ASC else SortItem.Direction.DESC
 
     Cypher.sort(
       container
-        .map(_.property(sortExpression.removeAlias()))
+        .map { case (propertyContainer, alias) =>
+          Neo4jUtil.getCorrectProperty(propertyContainer, sortExpression, alias)
+        }
         .getOrElse(Cypher.name(sortExpression.unquote())),
       direction
     )
@@ -229,29 +223,66 @@ class Neo4jQueryReadStrategy(
       )
     } else {
       requiredColumns.map(column => {
-        val splatColumn = column.split('.')
-        val entityName = splatColumn.head
+        // an aggregation is named after the function, e.g. `SUM(``target.price``)`, so the entity
+        // it belongs to has to be resolved from the column the aggregation is computed on
+        val alias = columnEntityAlias(aggregatedColumn(column).getOrElse(column))
 
-        val entity = if (entityName.contains(Neo4jUtil.RELATIONSHIP_ALIAS)) {
-          relationship
-        } else if (entityName.contains(Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS)) {
-          sourceNode
-        } else if (entityName.contains(Neo4jUtil.RELATIONSHIP_TARGET_ALIAS)) {
-          targetNode
-        } else {
-          null
-        }
+        val entity = alias
+          .map {
+            case Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS => sourceNode
+            case Neo4jUtil.RELATIONSHIP_TARGET_ALIAS => targetNode
+            case _                                   => relationship
+          }
+          .orNull
 
-        if (entity != null && splatColumn.length == 1) {
+        val name = column.unquote()
+        if (entity != null && alias.exists(a => name == a || name == s"<$a>")) {
           entity match {
-            case n: Node         => n.as(entityName.sanitizeSchemaName())
+            case n: Node         => n.as(column.sanitizeSchemaName())
             case r: Relationship => r.getRequiredSymbolicName
           }
         } else {
-          getCorrectProperty(column, entity)
+          getCorrectProperty(column, entity, alias)
         }
       })
     }
+  }
+
+  private val relationshipAliases =
+    Seq(Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS, Neo4jUtil.RELATIONSHIP_TARGET_ALIAS, Neo4jUtil.RELATIONSHIP_ALIAS)
+
+  /**
+   * The column an aggregation is computed on, e.g. `` `target.price` `` for
+   * `` SUM(`target.price`) ``. Aggregations over the whole row, like `COUNT(*)`, have none.
+   */
+  private def aggregatedColumn(column: String): Option[String] = aggregateColumns
+    .find(_.toString == column)
+    .flatMap {
+      case count: Count => Some(count.column().describe())
+      case max: Max     => Some(max.column().describe())
+      case min: Min     => Some(min.column().describe())
+      case sum: Sum     => Some(sum.column().describe())
+      case _            => None
+    }
+
+  /**
+   * Returns the alias of the relationship entity the given column is prefixed with, if any.
+   */
+  private def entityAlias(column: String): Option[String] = relationshipAliases.find(column.hasEntityAlias)
+
+  /**
+   * Same as [[entityAlias]], but it also recognises the internal fields, which wrap the alias in
+   * angle brackets, e.g. `<source.id>` or `<source>`.
+   */
+  private def columnEntityAlias(column: String): Option[String] = {
+    val name = column.unquote().stripPrefix("<")
+    relationshipAliases.find(alias => name == alias || name == s"$alias>" || name.hasEntityAlias(alias))
+  }
+
+  private def relationshipContainer(alias: String, relationship: Relationship): PropertyContainer = alias match {
+    case Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS => relationship.getLeft
+    case Neo4jUtil.RELATIONSHIP_TARGET_ALIAS => relationship.getRight
+    case _                                   => relationship
   }
 
   private def buildStatementAggregation(
@@ -332,16 +363,14 @@ class Neo4jQueryReadStrategy(
   private def filterRelationship(sourceNode: Node, targetNode: Node, relationship: Relationship) = {
     val matchQuery = Cypher.`match`(sourceNode).`match`(targetNode).`match`(relationship)
 
-    def getContainer(filter: Filter): PropertyContainer = {
-      if (filter.isAttribute(Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS)) {
-        sourceNode
-      } else if (filter.isAttribute(Neo4jUtil.RELATIONSHIP_TARGET_ALIAS)) {
-        targetNode
-      } else if (filter.isAttribute(Neo4jUtil.RELATIONSHIP_ALIAS)) {
-        relationship
-      } else {
-        throw new IllegalArgumentException(s"Attribute '${filter.getAttribute.get}' is not valid")
-      }
+    def getAlias(filter: Filter): String = relationshipAliases
+      .find(filter.hasEntityAlias)
+      .getOrElse(throw new IllegalArgumentException(s"Attribute '${filter.getAttribute.get}' is not valid"))
+
+    def getContainer(alias: String): PropertyContainer = alias match {
+      case Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS => sourceNode
+      case Neo4jUtil.RELATIONSHIP_TARGET_ALIAS => targetNode
+      case _                                   => relationship
     }
 
     if (filters.nonEmpty) {
@@ -350,7 +379,8 @@ class Neo4jQueryReadStrategy(
           case and: And => mapFilter(and.left).and(mapFilter(and.right))
           case or: Or   => mapFilter(or.left).or(mapFilter(or.right))
           case filter: Filter =>
-            Neo4jUtil.mapSparkFiltersToCypher(filter, getContainer(filter), filter.getAttributeWithoutEntityName)
+            val alias = getAlias(filter)
+            Neo4jUtil.mapSparkFiltersToCypher(filter, getContainer(alias), Some(alias))
         }
       }
 
@@ -361,10 +391,23 @@ class Neo4jQueryReadStrategy(
     matchQuery
   }
 
-  private def getCorrectProperty(column: String, entity: PropertyContainer): Expression = {
+  /**
+   * Builds the projection for a required column.
+   *
+   * `alias` must be set only when the column is prefixed with the alias of the entity it belongs
+   * to, as it happens for relationship reads: node, query and GDS columns carry no alias, so a dot
+   * there is part of the property name and must be kept.
+   */
+  private def getCorrectProperty(
+    column: String,
+    entity: PropertyContainer,
+    alias: Option[String] = None
+  ): Expression = {
     def propertyOrSymbolicName(col: String) = {
       if (entity != null) entity.property(col) else Cypher.name(col)
     }
+
+    def withoutAlias(col: String) = alias.map(col.removeEntityAlias).getOrElse(col.unquote())
 
     column match {
       case Neo4jUtil.INTERNAL_ID_FIELD => Functions.id(entity.asInstanceOf[Node]).as(Neo4jUtil.INTERNAL_ID_FIELD)
@@ -384,12 +427,10 @@ class Neo4jQueryReadStrategy(
         Functions.labels(entity.asInstanceOf[Node]).as(Neo4jUtil.INTERNAL_REL_TARGET_LABELS_FIELD)
       case "*" => Asterisk.INSTANCE
       case name => {
-        val cleanedName = name.removeAlias()
         aggregateColumns.find(_.toString == name)
           .map {
             case count: Count => {
-              val col = count.column().describe().unquote().removeAlias()
-              val prop = propertyOrSymbolicName(col)
+              val prop = propertyOrSymbolicName(withoutAlias(count.column().describe()))
               if (count.isDistinct) {
                 Functions.countDistinct(prop).as(name)
               } else {
@@ -397,17 +438,10 @@ class Neo4jQueryReadStrategy(
               }
             }
             case countStar: CountStar => Functions.count(Asterisk.INSTANCE).as(name)
-            case max: Max =>
-              val col = max.column().describe().unquote().removeAlias()
-              val prop = propertyOrSymbolicName(col)
-              Functions.max(prop).as(name)
-            case min: Min =>
-              val col = min.column().describe().unquote().removeAlias()
-              val prop = propertyOrSymbolicName(col)
-              Functions.min(prop).as(name)
+            case max: Max => Functions.max(propertyOrSymbolicName(withoutAlias(max.column().describe()))).as(name)
+            case min: Min => Functions.min(propertyOrSymbolicName(withoutAlias(min.column().describe()))).as(name)
             case sum: Sum => {
-              val col = sum.column().describe().unquote().removeAlias()
-              val prop = propertyOrSymbolicName(col)
+              val prop = propertyOrSymbolicName(withoutAlias(sum.column().describe()))
               if (sum.isDistinct) {
                 Functions.sumDistinct(prop).as(name)
               } else {
@@ -415,7 +449,7 @@ class Neo4jQueryReadStrategy(
               }
             }
           }
-          .getOrElse(propertyOrSymbolicName(cleanedName).as(name))
+          .getOrElse(propertyOrSymbolicName(withoutAlias(name)).as(name))
           .asInstanceOf[Expression]
       }
     }

--- a/common/src/main/scala/org/neo4j/spark/util/Neo4jImplicits.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Neo4jImplicits.scala
@@ -61,6 +61,12 @@ object Neo4jImplicits {
 
   private val BACKTICK = "`"
 
+  /**
+   * Matches one segment of a property path: either a backtick quoted name,
+   * which can contain dots, or a run of characters up to the next dot.
+   */
+  private val PATH_SEGMENT = """`([^`]*)`|([^.`]+)""".r
+
   implicit class CypherImplicits(str: String) {
 
     def sanitizeSchemaName(): String = {
@@ -79,15 +85,48 @@ object Neo4jImplicits {
 
     def unquote(): String = str.replaceAll(BACKTICK, "")
 
-    def removeAlias(): String = {
-      val splatString = str.unquote().split('.')
+    /**
+     * Splits a, possibly backtick quoted, property path into its segments.
+     *
+     * Dots inside backticks belong to the property name, so `` `table.key` `` is a single property
+     * named `table.key`, while `location.x` is the `x` field of the `location` property.
+     */
+    def propertyPath(): Seq[String] = {
+      val segments = PATH_SEGMENT.findAllMatchIn(str)
+        .map(m => Option(m.group(1)).getOrElse(m.group(2)))
+        .toSeq
 
-      if (splatString.size > 1) {
-        splatString.tail.mkString(".")
-      } else {
-        str
+      if (segments.isEmpty) Seq(str) else segments
+    }
+
+    /**
+     * Removes the given entity alias (`source`, `target` or `rel`) from the head of the property
+     * path, leaving the rest of the path untouched.
+     *
+     * Only the alias is removed, not everything up to the first dot: `source.table.key` is the
+     * `table.key` property of the `source` node, not the `key` field of its `table` property.
+     */
+    def propertyPathWithoutAlias(alias: String): Seq[String] = {
+      val path = str.propertyPath()
+      val prefix = s"$alias."
+
+      path.head match {
+        case head if head.startsWith(prefix) => head.substring(prefix.length) +: path.tail
+        case `alias` if path.size > 1        => path.tail
+        case _                               => path
       }
     }
+
+    def hasEntityAlias(alias: String): Boolean = {
+      val path = str.propertyPath()
+
+      path.head.startsWith(s"$alias.") || (path.head == alias && path.size > 1)
+    }
+
+    /**
+     * Same as [[propertyPathWithoutAlias]], for the callers that need the path back as a string.
+     */
+    def removeEntityAlias(alias: String): String = str.propertyPathWithoutAlias(alias).mkString(".")
 
     /**
      * df: we need this to handle scenarios like `WHERE age > 19 and age < 22`,
@@ -210,8 +249,13 @@ object Neo4jImplicits {
       }
     }
 
+    /**
+     * Spark keeps the field names of a reference separate, so it already knows whether `a.b` is a
+     * property literally named `a.b` or the `b` field of the `a` property. Quoting each field name
+     * preserves that information once the reference is flattened into a single string.
+     */
     def rawAttributeName(): String = {
-      predicate.references().head.fieldNames().mkString(".")
+      predicate.references().head.fieldNames().map(_.sanitizeSchemaName()).mkString(".")
     }
 
     def rawLiteralValue(options: Neo4jOptions): Option[Value] = {
@@ -272,12 +316,7 @@ object Neo4jImplicits {
       case _                           => null
     })
 
-    def isAttribute(entityType: String): Boolean = {
-      getAttribute.exists(_.contains(s"$entityType."))
-    }
-
-    def getAttributeWithoutEntityName: Option[String] =
-      filter.getAttribute.map(_.unquote().split('.').tail.mkString("."))
+    def hasEntityAlias(alias: String): Boolean = getAttribute.exists(_.hasEntityAlias(alias))
 
     /**
      * df: we are not handling AND/OR because they are not actually filters

--- a/common/src/main/scala/org/neo4j/spark/util/Neo4jUtil.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Neo4jUtil.scala
@@ -132,8 +132,22 @@ object Neo4jUtil {
     .map(_ => "databricks")
     .getOrElse("spark")
 
-  def getCorrectProperty(container: PropertyContainer, attribute: String): Property = {
-    container.property(attribute.split('.'): _*)
+  /**
+   * Builds the property access for a Spark attribute.
+   *
+   * `entityAlias` must be set when the attribute is prefixed with the alias of the container
+   * (`source`, `target` or `rel`), as it happens for relationship reads.
+   */
+  def getCorrectProperty(
+    container: PropertyContainer,
+    attribute: String,
+    entityAlias: Option[String] = None
+  ): Property = {
+    val path = entityAlias
+      .map(attribute.propertyPathWithoutAlias)
+      .getOrElse(attribute.propertyPath())
+
+    container.property(path: _*)
   }
 
   def paramsFromFilters(filters: Array[Filter]): Map[String, Any] = {
@@ -163,44 +177,37 @@ object Neo4jUtil {
   def mapSparkFiltersToCypher(
     filter: Filter,
     container: PropertyContainer,
-    attributeAlias: Option[String] = None
+    entityAlias: Option[String] = None
   ): Condition = {
+    def property(attribute: String): Property = getCorrectProperty(container, attribute, entityAlias)
+
     filter match {
       case eqns: EqualNullSafe =>
         val parameter = valueToCypherExpression(eqns.attribute, eqns.value)
-        val property = getCorrectProperty(container, attributeAlias.getOrElse(eqns.attribute))
-        property.isNull.and(parameter.isNull)
-          .or(property.isEqualTo(parameter))
+        val prop = property(eqns.attribute)
+        prop.isNull.and(parameter.isNull)
+          .or(prop.isEqualTo(parameter))
       case eq: EqualTo =>
-        getCorrectProperty(container, attributeAlias.getOrElse(eq.attribute))
-          .isEqualTo(valueToCypherExpression(eq.attribute, eq.value))
+        property(eq.attribute).isEqualTo(valueToCypherExpression(eq.attribute, eq.value))
       case gt: GreaterThan =>
-        getCorrectProperty(container, attributeAlias.getOrElse(gt.attribute))
-          .gt(valueToCypherExpression(gt.attribute, gt.value))
+        property(gt.attribute).gt(valueToCypherExpression(gt.attribute, gt.value))
       case gte: GreaterThanOrEqual =>
-        getCorrectProperty(container, attributeAlias.getOrElse(gte.attribute))
-          .gte(valueToCypherExpression(gte.attribute, gte.value))
+        property(gte.attribute).gte(valueToCypherExpression(gte.attribute, gte.value))
       case lt: LessThan =>
-        getCorrectProperty(container, attributeAlias.getOrElse(lt.attribute))
-          .lt(valueToCypherExpression(lt.attribute, lt.value))
+        property(lt.attribute).lt(valueToCypherExpression(lt.attribute, lt.value))
       case lte: LessThanOrEqual =>
-        getCorrectProperty(container, attributeAlias.getOrElse(lte.attribute))
-          .lte(valueToCypherExpression(lte.attribute, lte.value))
+        property(lte.attribute).lte(valueToCypherExpression(lte.attribute, lte.value))
       case in: In =>
-        getCorrectProperty(container, attributeAlias.getOrElse(in.attribute))
-          .in(valueToCypherExpression(in.attribute, in.values))
+        property(in.attribute).in(valueToCypherExpression(in.attribute, in.values))
       case startWith: StringStartsWith =>
-        getCorrectProperty(container, attributeAlias.getOrElse(startWith.attribute))
-          .startsWith(valueToCypherExpression(startWith.attribute, startWith.value))
+        property(startWith.attribute).startsWith(valueToCypherExpression(startWith.attribute, startWith.value))
       case endsWith: StringEndsWith =>
-        getCorrectProperty(container, attributeAlias.getOrElse(endsWith.attribute))
-          .endsWith(valueToCypherExpression(endsWith.attribute, endsWith.value))
+        property(endsWith.attribute).endsWith(valueToCypherExpression(endsWith.attribute, endsWith.value))
       case contains: StringContains =>
-        getCorrectProperty(container, attributeAlias.getOrElse(contains.attribute))
-          .contains(valueToCypherExpression(contains.attribute, contains.value))
-      case notNull: IsNotNull => getCorrectProperty(container, attributeAlias.getOrElse(notNull.attribute)).isNotNull
-      case isNull: IsNull     => getCorrectProperty(container, attributeAlias.getOrElse(isNull.attribute)).isNull
-      case not: Not           => mapSparkFiltersToCypher(not.child, container, attributeAlias).not()
+        property(contains.attribute).contains(valueToCypherExpression(contains.attribute, contains.value))
+      case notNull: IsNotNull => property(notNull.attribute).isNotNull
+      case isNull: IsNull     => property(isNull.attribute).isNull
+      case not: Not           => mapSparkFiltersToCypher(not.child, container, entityAlias).not()
       case _: AlwaysTrue      => Cypher.literalTrue().asCondition()
       case _: AlwaysFalse     => Cypher.literalFalse().asCondition()
       case unsupported =>

--- a/common/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
+++ b/common/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
@@ -127,6 +127,69 @@ class Neo4jQueryServiceTest {
 
   @Test
   @Parameters(method = "versions_and_prefixes")
+  def testNodeOneLabelWithSelectedColumnsContainingDots(neo4j: Neo4j, prefix: String): Unit = {
+    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    options.put(Neo4jOptions.URL, "bolt://localhost")
+    options.put(QueryType.LABELS.toString.toLowerCase, "Person")
+    val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+
+    val query: String = new Neo4jQueryService(
+      neo4jOptions,
+      new Neo4jQueryReadStrategy(neo4j, Array.empty[Filter], PartitionPagination.EMPTY, List("table.key", "a.b.c"))
+    ).createQuery()
+
+    assertEquals(
+      s"${prefix}MATCH (n:`Person`) RETURN n.`table.key` AS `table.key`, n.`a.b.c` AS `a.b.c`",
+      query
+    )
+  }
+
+  @Test
+  @Parameters(method = "versions_and_prefixes")
+  def testNodeFilterOnColumnWhoseNameContainsDots(neo4j: Neo4j, prefix: String): Unit = {
+    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    options.put(Neo4jOptions.URL, "bolt://localhost")
+    options.put(QueryType.LABELS.toString.toLowerCase, "Person")
+    val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+
+    val filters: Array[Filter] = Array[Filter](
+      EqualTo("`table.key`", "value"),
+      EqualTo("`a.b.c`", "value")
+    )
+
+    val query: String = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(neo4j, filters)).createQuery()
+
+    val tableKeyParam = "$" + "`table.key`".toParameterName("value")
+    val abcParam = "$" + "`a.b.c`".toParameterName("value")
+
+    assertEquals(
+      s"${prefix}MATCH (n:`Person`) " +
+        s"WHERE (n.`table.key` = $tableKeyParam AND n.`a.b.c` = $abcParam) RETURN n",
+      query
+    )
+  }
+
+  @Test
+  @Parameters(method = "versions_and_prefixes")
+  def testNodeFilterOnNestedField(neo4j: Neo4j, prefix: String): Unit = {
+    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    options.put(Neo4jOptions.URL, "bolt://localhost")
+    options.put(QueryType.LABELS.toString.toLowerCase, "Person")
+    val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+
+    val filters: Array[Filter] = Array[Filter](
+      GreaterThan("location.x", 0)
+    )
+
+    val query: String = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(neo4j, filters)).createQuery()
+
+    val paramName = "$" + "location.x".toParameterName(0)
+
+    assertEquals(s"${prefix}MATCH (n:`Person`) WHERE n.location.x > $paramName RETURN n", query)
+  }
+
+  @Test
+  @Parameters(method = "versions_and_prefixes")
   def testNodeOneLabelWithInternalIdSelected(neo4j: Neo4j, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
@@ -292,6 +355,69 @@ class Neo4jQueryServiceTest {
       s"${prefix}MATCH (source:`Person`) " +
         "MATCH (target:`Person`) " +
         "MATCH (source)-[rel:`KNOWS`]->(target) RETURN source.name AS `source.name`, id(source) AS `<source.id>`",
+      query
+    )
+  }
+
+  @Test
+  @Parameters(method = "versions_and_prefixes")
+  def testRelationshipWithSelectedColumnsContainingDots(neo4j: Neo4j, prefix: String): Unit = {
+    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    options.put(Neo4jOptions.URL, "bolt://localhost")
+    options.put("relationship", "KNOWS")
+    options.put("relationship.nodes.map", "false")
+    options.put("relationship.source.labels", "Person")
+    options.put("relationship.target.labels", "Person")
+    val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+
+    val query: String = new Neo4jQueryService(
+      neo4jOptions,
+      new Neo4jQueryReadStrategy(
+        neo4j,
+        Array.empty[Filter],
+        PartitionPagination.EMPTY,
+        List("source.table.key", "target.a.b.c", "rel.table.key")
+      )
+    ).createQuery()
+
+    assertEquals(
+      s"${prefix}MATCH (source:`Person`) " +
+        "MATCH (target:`Person`) " +
+        "MATCH (source)-[rel:`KNOWS`]->(target) " +
+        "RETURN source.`table.key` AS `source.table.key`, " +
+        "target.`a.b.c` AS `target.a.b.c`, " +
+        "rel.`table.key` AS `rel.table.key`",
+      query
+    )
+  }
+
+  @Test
+  @Parameters(method = "versions_and_prefixes")
+  def testRelationshipFilterOnColumnWhoseNameContainsDots(neo4j: Neo4j, prefix: String): Unit = {
+    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    options.put(Neo4jOptions.URL, "bolt://localhost")
+    options.put("relationship", "KNOWS")
+    options.put("relationship.nodes.map", "false")
+    options.put("relationship.source.labels", "Person")
+    options.put("relationship.target.labels", "Person")
+    val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+
+    val filters: Array[Filter] = Array[Filter](
+      EqualTo("`source.table.key`", "value"),
+      EqualTo("`rel.a.b.c`", "value")
+    )
+
+    val query: String = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(neo4j, filters)).createQuery()
+
+    val sourceParam = "$" + "`source.table.key`".toParameterName("value")
+    val relParam = "$" + "`rel.a.b.c`".toParameterName("value")
+
+    assertEquals(
+      s"${prefix}MATCH (source:`Person`) " +
+        "MATCH (target:`Person`) " +
+        "MATCH (source)-[rel:`KNOWS`]->(target) " +
+        s"WHERE (source.`table.key` = $sourceParam AND rel.`a.b.c` = $relParam) " +
+        "RETURN rel, source AS source, target AS target",
       query
     )
   }
@@ -682,6 +808,64 @@ class Neo4jQueryServiceTest {
           |MERGE (source)-[rel:`DID BUY`{`transaction identifier`: event.rel.keys.transactionId}]->(target)
           |SET rel += event.rel.properties
           |""".stripMargin,
+      query
+    )
+  }
+
+  @Test
+  @Parameters(method = "versions_and_prefixes")
+  def testShouldDoAggregationOnLabelsWithColumnsContainingDots(neo4j: Neo4j, prefix: String): Unit = {
+    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    options.put(Neo4jOptions.URL, "bolt://localhost")
+    options.put(QueryType.LABELS.toString.toLowerCase, "Person")
+    val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+
+    val nestedField = new DummyNamedReference("`a.b.c`")
+    val query: String = new Neo4jQueryService(
+      neo4jOptions,
+      new Neo4jQueryReadStrategy(
+        neo4j,
+        Array.empty[Filter],
+        PartitionPagination.EMPTY,
+        Seq("table.key", "MAX(`a.b.c`)"),
+        Array(new Max(nestedField))
+      )
+    ).createQuery()
+
+    assertEquals(
+      s"${prefix}MATCH (n:`Person`) RETURN n.`table.key` AS `table.key`, max(n.`a.b.c`) AS `MAX(``a.b.c``)`",
+      query
+    )
+  }
+
+  @Test
+  @Parameters(method = "versions_and_prefixes")
+  def testShouldDoAggregationOnRelationshipWithColumnsContainingDots(neo4j: Neo4j, prefix: String): Unit = {
+    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    options.put(Neo4jOptions.URL, "bolt://localhost")
+    options.put("relationship", "BOUGHT")
+    options.put("relationship.nodes.map", "false")
+    options.put("relationship.source.labels", "Person")
+    options.put("relationship.target.labels", "Product")
+    val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+
+    val nestedField = new DummyNamedReference("`target.a.b.c`")
+    val query: String = new Neo4jQueryService(
+      neo4jOptions,
+      new Neo4jQueryReadStrategy(
+        neo4j,
+        Array.empty[Filter],
+        PartitionPagination.EMPTY,
+        Seq("source.table.key", "SUM(`target.a.b.c`)"),
+        Array(new Sum(nestedField, false))
+      )
+    ).createQuery()
+
+    assertEquals(
+      s"${prefix}MATCH (source:`Person`) " +
+        "MATCH (target:`Product`) " +
+        "MATCH (source)-[rel:`BOUGHT`]->(target) " +
+        "RETURN source.`table.key` AS `source.table.key`, sum(target.`a.b.c`) AS `SUM(``target.a.b.c``)`",
       query
     )
   }

--- a/common/src/test/scala/org/neo4j/spark/util/Neo4jImplicitsTest.scala
+++ b/common/src/test/scala/org/neo4j/spark/util/Neo4jImplicitsTest.scala
@@ -156,19 +156,52 @@ class Neo4jImplicitsTest {
   }
 
   @Test
-  def `should return the attribute without the entity identifier`(): Unit = {
-    // given
-    val filter = EqualTo("person.address.coords", 32)
-
-    // when
-    val attribute = filter.getAttributeWithoutEntityName
-
-    // then
-    assertEquals("address.coords", attribute.get)
+  def `should detect the entity alias` {
+    assertTrue(EqualTo("source.name", "John").hasEntityAlias("source"))
+    assertTrue(EqualTo("`source.name`", "John").hasEntityAlias("source"))
+    assertTrue(EqualTo("`source.table.key`", "John").hasEntityAlias("source"))
+    assertTrue(EqualTo("`rel.since`", 32).hasEntityAlias("rel"))
   }
 
   @Test
-  def `struct should return true if contains fields`(): Unit = {
+  def `should not detect an entity alias when it is only part of the property name` {
+    assertFalse(EqualTo("`mysource.name`", "John").hasEntityAlias("source"))
+    assertFalse(EqualTo("`name.source.x`", "John").hasEntityAlias("source"))
+    assertFalse(EqualTo("source", "John").hasEntityAlias("source"))
+  }
+
+  @Test
+  def `should split a nested property access` {
+    assertEquals(Seq("location", "x"), "location.x".propertyPath())
+  }
+
+  @Test
+  def `should keep a quoted property name as a single segment` {
+    assertEquals(Seq("table.key"), "`table.key`".propertyPath())
+    assertEquals(Seq("a.b.c"), "`a.b.c`".propertyPath())
+  }
+
+  @Test
+  def `should split a nested access on a quoted property name` {
+    assertEquals(Seq("table.key", "x"), "`table.key`.x".propertyPath())
+  }
+
+  @Test
+  def `should remove the entity alias keeping the dots of the property name` {
+    assertEquals("table.key", "`source.table.key`".removeEntityAlias("source"))
+    assertEquals("a.b.c", "`source.a.b.c`".removeEntityAlias("source"))
+    assertEquals("name", "source.name".removeEntityAlias("source"))
+    assertEquals("location.x", "`source.location`.x".removeEntityAlias("source"))
+  }
+
+  @Test
+  def `should leave the property untouched when it is not prefixed with the alias` {
+    assertEquals("table.key", "`table.key`".removeEntityAlias("source"))
+    assertEquals("mysource.key", "`mysource.key`".removeEntityAlias("source"))
+  }
+
+  @Test
+  def `struct should return true if contains fields`: Unit = {
     val struct = StructType(Seq(
       StructField("is_hero", DataTypes.BooleanType),
       StructField("name", DataTypes.StringType),

--- a/spark-3/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
+++ b/spark-3/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
@@ -1146,6 +1146,115 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
   }
 
   @Test
+  def testReadNodeWithPropertyNamesContainingDots(): Unit = {
+    executeQuery("CREATE (m:Map {`table.key`: 'value', `a.b.c`: 'nested value', plain: 'plain value'})")
+
+    val df = ss.read.format(classOf[DataSource].getName)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("labels", "Map")
+      .load()
+
+    val rows = df.collectAsList()
+
+    assertEquals(1, rows.size())
+    assertEquals("value", rows.get(0).getAs[String]("table.key"))
+    assertEquals("nested value", rows.get(0).getAs[String]("a.b.c"))
+    assertEquals("plain value", rows.get(0).getAs[String]("plain"))
+  }
+
+  @Test
+  def testFilterNodeOnPropertyNamesContainingDots(): Unit = {
+    executeQuery(
+      """CREATE (:Map {`table.key`: 'value', `a.b.c`: 'nested value'})
+        |CREATE (:Map {`table.key`: 'another value', `a.b.c`: 'another nested value'})""".stripMargin
+    )
+
+    val df = ss.read.format(classOf[DataSource].getName)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("labels", "Map")
+      .load()
+      .select("`table.key`")
+      .where("`a.b.c` = 'nested value'")
+
+    val rows = df.collectAsList()
+
+    assertEquals(1, rows.size())
+    assertEquals("value", rows.get(0).getAs[String]("table.key"))
+  }
+
+  @Test
+  def testReadRelationshipWithPropertyNamesContainingDots(): Unit = {
+    executeQuery(
+      """CREATE (s:MapSource {`table.key`: 'source value', `a.b.c`: 'source nested value'})
+        |CREATE (t:MapTarget {`table.key`: 'target value', `a.b.c`: 'target nested value'})
+        |CREATE (s)-[:MAPS {`table.key`: 'rel value', `a.b.c`: 'rel nested value'}]->(t)""".stripMargin
+    )
+
+    val df = ss.read.format(classOf[DataSource].getName)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("relationship.nodes.map", "false")
+      .option("relationship.source.labels", "MapSource")
+      .option("relationship", "MAPS")
+      .option("relationship.target.labels", "MapTarget")
+      .load()
+
+    val rows = df.collectAsList()
+
+    assertEquals(1, rows.size())
+    val row = rows.get(0)
+    assertEquals("source value", row.getAs[String]("source.table.key"))
+    assertEquals("source nested value", row.getAs[String]("source.a.b.c"))
+    assertEquals("target value", row.getAs[String]("target.table.key"))
+    assertEquals("target nested value", row.getAs[String]("target.a.b.c"))
+    assertEquals("rel value", row.getAs[String]("rel.table.key"))
+    assertEquals("rel nested value", row.getAs[String]("rel.a.b.c"))
+  }
+
+  @Test
+  def testFilterRelationshipOnPropertyNamesContainingDots(): Unit = {
+    executeQuery(
+      """CREATE (s:MapSource {`table.key`: 'source value', `a.b.c`: 'source nested value'})
+        |CREATE (t:MapTarget {`table.key`: 'target value'})
+        |CREATE (s)-[:MAPS {`table.key`: 'rel value'}]->(t)
+        |CREATE (s2:MapSource {`table.key`: 'another source value', `a.b.c`: 'another nested value'})
+        |CREATE (t2:MapTarget {`table.key`: 'another target value'})
+        |CREATE (s2)-[:MAPS {`table.key`: 'another rel value'}]->(t2)""".stripMargin
+    )
+
+    val df = ss.read.format(classOf[DataSource].getName)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("relationship.nodes.map", "false")
+      .option("relationship.source.labels", "MapSource")
+      .option("relationship", "MAPS")
+      .option("relationship.target.labels", "MapTarget")
+      .load()
+      .select("`rel.table.key`", "`target.table.key`")
+      .where("`source.a.b.c` = 'source nested value'")
+
+    val rows = df.collectAsList()
+
+    assertEquals(1, rows.size())
+    assertEquals("rel value", rows.get(0).getAs[String]("rel.table.key"))
+    assertEquals("target value", rows.get(0).getAs[String]("target.table.key"))
+  }
+
+  @Test
+  def testReadQueryWithColumnNamesContainingDots(): Unit = {
+    executeQuery("CREATE (m:Map {`table.key`: 'value', `a.b.c`: 'nested value'})")
+
+    val df = ss.read.format(classOf[DataSource].getName)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("query", "MATCH (m:Map) RETURN m.`table.key` AS `table.key`, m.`a.b.c` AS `a.b.c`")
+      .load()
+
+    val rows = df.collectAsList()
+
+    assertEquals(1, rows.size())
+    assertEquals("value", rows.get(0).getAs[String]("table.key"))
+    assertEquals("nested value", rows.get(0).getAs[String]("a.b.c"))
+  }
+
+  @Test
   def testQueries(): Unit = {
     val dfMap = ss.read.format(classOf[DataSource].getName)
       .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
@@ -1921,13 +2030,17 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
     assertEquals(Set("target.name", "target.id"), df.columns.toSet)
   }
 
-  private def initTest(query: String): DataFrame = {
+  private def executeQuery(query: String): Unit = {
     SparkConnectorScalaSuiteIT.session()
       .writeTransaction(
         new TransactionWork[ResultSummary] {
           override def execute(tx: Transaction): ResultSummary = tx.run(query).consume()
         }
       )
+  }
+
+  private def initTest(query: String): DataFrame = {
+    executeQuery(query)
 
     ss.read.format(classOf[DataSource].getName)
       .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)


### PR DESCRIPTION
This bug is related to all properties containing dot, not only packaged map structs.

The existing implementation treats dot primarily as separator between an alias and a property, and strips it when reading. For example flattened map property mymap.myproperty becomes myproperty and thus always read as null.

In reality, the dot has 3 possible meanings:

an alias
part of the property
nested field access (for example in points).
This PR addresses this ambiguity. It makes alias stripping explicit and requires the exact alias name, where possible. Filter encoding also uses extra backticks to distinguish between property name and field access.

Backported from https://github.com/neo4j/neo4j-spark-connector/pull/1117