### PR TITLE
fix: remove create optimizations from stream reader

### DIFF
--- a/spark-3/src/main/scala/org/neo4j/spark/streaming/Neo4jMicroBatchReader.scala
+++ b/spark-3/src/main/scala/org/neo4j/spark/streaming/Neo4jMicroBatchReader.scala
@@ -43,7 +43,6 @@ class Neo4jMicroBatchReader(
 
   private lazy val scriptResult = {
     val schemaService = new SchemaService(neo4j, neo4jOptions, driverCache)
-    schemaService.createOptimizations(schema)
     val scriptResult = schemaService.execute(neo4jOptions.script)
     schemaService.close()
     scriptResult


### PR DESCRIPTION
The reader shouldn't modify the schema.