### PR TITLE
feat: introduce an option to fail on unknown commit state

### DIFF
--- a/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
+++ b/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
@@ -235,7 +235,11 @@ class Neo4jOptions(private val options: Map[String, String]) extends Serializabl
       .toSet
     val batchSize = getParameter(BATCH_SIZE, DEFAULT_BATCH_SIZE.toString).toInt
     val retryTimeout = getParameter(TRANSACTION_RETRY_TIMEOUT, DEFAULT_TRANSACTION_RETRY_TIMEOUT.toString).toInt
-    Neo4jTransactionSettings(retries, failOnTransactionCodes, batchSize, retryTimeout)
+    val unknownCommitOutcome = UnknownCommitOutcome.withCaseInsensitiveName(getParameter(
+      TRANSACTION_COMMIT_UNKNOWN_OUTCOME,
+      DEFAULT_TRANSACTION_COMMIT_UNKNOWN_OUTCOME.toString
+    ))
+    Neo4jTransactionSettings(retries, failOnTransactionCodes, batchSize, retryTimeout, unknownCommitOutcome)
   }
 
   val relationshipMetadata: Neo4jRelationshipMetadata = initNeo4jRelationshipMetadata()
@@ -439,7 +443,8 @@ case class Neo4jTransactionSettings(
   retries: Int,
   failOnTransactionCodes: Set[String],
   batchSize: Int,
-  retryTimeout: Long
+  retryTimeout: Long,
+  unknownCommitOutcome: UnknownCommitOutcome.Value = Neo4jOptions.DEFAULT_TRANSACTION_COMMIT_UNKNOWN_OUTCOME
 ) {
 
   def shouldFailOn(exception: Throwable): Boolean = {
@@ -732,6 +737,7 @@ object Neo4jOptions {
   val TRANSACTION_RETRIES = "transaction.retries"
   val TRANSACTION_RETRY_TIMEOUT = "transaction.retry.timeout"
   val TRANSACTION_CODES_FAIL = "transaction.codes.fail"
+  val TRANSACTION_COMMIT_UNKNOWN_OUTCOME = "transaction.commit.unknown.outcome"
 
   // Transaction metadata
   private val TX_METADATA_OPTION_PREFIX = "db.transaction.metadata."
@@ -765,6 +771,7 @@ object Neo4jOptions {
   val DEFAULT_BATCH_SIZE = 5000
   val DEFAULT_TRANSACTION_RETRIES = 3
   val DEFAULT_TRANSACTION_RETRY_TIMEOUT = 0
+  val DEFAULT_TRANSACTION_COMMIT_UNKNOWN_OUTCOME: UnknownCommitOutcome.Value = UnknownCommitOutcome.RETRY
   val DEFAULT_TRANSACTION_TIMEOUT = null
   val DEFAULT_RELATIONSHIP_NODES_MAP = false
   val DEFAULT_SCHEMA_STRATEGY = SchemaStrategy.SAMPLE
@@ -864,4 +871,17 @@ object ConstraintsOptimizationType extends CaseInsensitiveEnumeration {
 
 object SchemaConstraintsOptimizationType extends CaseInsensitiveEnumeration {
   val TYPE, EXISTS, NONE = Value
+}
+
+/**
+ * What a task does when a transaction commit fails in a way that leaves the outcome unknown, i.e. when the
+ * connection to the server drops while the connector is waiting for the answer to a `COMMIT` message. The server
+ * may or may not have applied the transaction, and there is no way to ask it afterwards.
+ *
+ *   - `RETRY` replays the batch. This is the historical behaviour: it never fails the job for this reason, but it
+ *     duplicates the batch whenever the lost commit had in fact been applied and the write is not idempotent.
+ *   - `FAIL` fails the task with a [[Neo4jUnknownCommitOutcomeException]] without replaying the batch.
+ */
+object UnknownCommitOutcome extends CaseInsensitiveEnumeration {
+  val RETRY, FAIL = Value
 }

--- a/src/main/scala/org/neo4j/spark/util/Neo4jUnknownCommitOutcomeException.scala
+++ b/src/main/scala/org/neo4j/spark/util/Neo4jUnknownCommitOutcomeException.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.spark.util
+
+/**
+ * Thrown when a batch could not be written because the outcome of its transaction commit is unknown, and the
+ * configured `transaction.commit.unknown.outcome` policy does not allow the connector to replay it blindly.
+ *
+ * The batch may or may not be in the database. The connector deliberately does not guess.
+ */
+class Neo4jUnknownCommitOutcomeException(message: String, cause: Throwable)
+    extends RuntimeException(message, cause)

--- a/src/main/scala/org/neo4j/spark/util/Neo4jUtil.scala
+++ b/src/main/scala/org/neo4j/spark/util/Neo4jUtil.scala
@@ -27,6 +27,8 @@ import org.neo4j.cypherdsl.core._
 import org.neo4j.driver.Session
 import org.neo4j.driver.Transaction
 import org.neo4j.driver.exceptions.RetryableException
+import org.neo4j.driver.exceptions.ServiceUnavailableException
+import org.neo4j.driver.exceptions.SessionExpiredException
 import org.neo4j.driver.types.Entity
 import org.neo4j.driver.types.Path
 import org.neo4j.spark.service.SchemaService
@@ -253,6 +255,29 @@ object Neo4jUtil {
       exception.isInstanceOf[RetryableException] || isRetryableException(
         exception.getCause
       )
+  }
+
+  /**
+   * Whether the exception reports a lost connection rather than an answer from the server.
+   *
+   * This is the distinction that matters for a failed `COMMIT`: a server that answers `COMMIT` with a failure has
+   * definitely not applied the transaction, while a connection that dies while the answer is in flight leaves the
+   * outcome unknown.
+   *
+   * `ConnectionReadTimeoutException` extends `ServiceUnavailableException` and is therefore covered too, as is a
+   * `SessionExpiredException` raised because a routed connection dropped. Note that `SessionExpiredException` is
+   * also how the driver reports `Neo.ClientError.Cluster.NotALeader`, which *is* a definite answer; telling the two
+   * apart would mean inspecting the `org.neo4j.bolt.connection` cause types, which are driver internals. Treating
+   * both as a lost connection errs on the safe side.
+   */
+  @tailrec
+  def isConnectionFailure(exception: Throwable): Boolean = {
+    if (exception == null) {
+      false
+    } else
+      exception.isInstanceOf[ServiceUnavailableException] ||
+      exception.isInstanceOf[SessionExpiredException] ||
+      isConnectionFailure(exception.getCause)
   }
 
 }

--- a/src/main/scala/org/neo4j/spark/writer/BaseDataWriter.scala
+++ b/src/main/scala/org/neo4j/spark/writer/BaseDataWriter.scala
@@ -32,8 +32,11 @@ import org.neo4j.spark.cypher.QueryEmbedder
 import org.neo4j.spark.service._
 import org.neo4j.spark.util.DriverCache
 import org.neo4j.spark.util.Neo4jOptions
+import org.neo4j.spark.util.Neo4jUnknownCommitOutcomeException
 import org.neo4j.spark.util.Neo4jUtil.closeSafely
+import org.neo4j.spark.util.Neo4jUtil.isConnectionFailure
 import org.neo4j.spark.util.Neo4jUtil.isRetryableException
+import org.neo4j.spark.util.UnknownCommitOutcome
 
 import java.io.Closeable
 import java.time.Duration
@@ -41,7 +44,6 @@ import java.util
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.locks.LockSupport
 
-import scala.annotation.tailrec
 import scala.jdk.CollectionConverters.MapHasAsJava
 
 abstract class BaseDataWriter(
@@ -53,6 +55,8 @@ abstract class BaseDataWriter(
   options: Neo4jOptions,
   scriptResult: java.util.List[java.util.Map[String, AnyRef]]
 ) extends Logging with Closeable with DataWriter[InternalRow] {
+
+  import BaseDataWriter._
 
   private val STOPPED_THREAD_EXCEPTION_MESSAGE =
     "Connection to the database terminated. Thread interrupted while committing the transaction"
@@ -90,8 +94,25 @@ abstract class BaseDataWriter(
     }
   }
 
-  @tailrec
   private def writeBatch(): Unit = {
+    var retry = true
+    while (retry) {
+      retry = false
+      try {
+        attemptBatch()
+      } catch {
+        case failure: BatchAttemptFailure => retry = handleFailure(failure)
+      }
+    }
+  }
+
+  /**
+   * Runs the batch once, tracking how far it got so that a failure can be interpreted. Any failure is wrapped in a
+   * [[BatchAttemptFailure]] carrying that phase, which is what makes the difference between "the server never
+   * applied this" and "the server may have applied this" visible to the caller.
+   */
+  private def attemptBatch(): Unit = {
+    var phase: CommitPhase = BeforeCommit
     try {
       if (session == null || !session.isOpen) {
         session = driverCache.getOrCreate().session(options.session.toNeo4jSession())
@@ -127,12 +148,12 @@ abstract class BaseDataWriter(
              |""".stripMargin
         )
       }
-      transaction.commit()
 
-      if (skipped > 0) {
-        log.info(s"Skipped $skipped rows that contained null values in one of their key property values.")
-        skipped = 0
-      }
+      phase = Committing
+      transaction.commit()
+      phase = Committed
+
+      logSkipped()
 
       // update metrics
       metrics.applyCounters(batch.size(), counters)
@@ -140,24 +161,90 @@ abstract class BaseDataWriter(
       closeSafely(transaction)
       batch.clear()
     } catch {
-      case e: Throwable =>
-        if (options.transactionSettings.shouldFailOn(e)) {
-          log.error("unable to write batch due to explicitly configured failure condition", e)
-          throw e
-        }
+      case e: Throwable => throw new BatchAttemptFailure(phase, e)
+    }
+  }
 
-        if (isRetryableException(e) && retries.getCount > 0) {
-          retries.countDown()
-          log.info(
-            s"encountered a transient exception while writing batch, retrying ${options.transactionSettings.retries - retries.getCount} time",
-            e
-          )
-          close()
-          LockSupport.parkNanos(Duration.ofMillis(options.transactionSettings.retryTimeout).toNanos)
-          writeBatch()
-        } else {
-          logAndThrowException(e)
-        }
+  /**
+   * @return `true` if the batch should be attempted again, `false` if it is done. Throws if the task must fail.
+   */
+  private def handleFailure(failure: BatchAttemptFailure): Boolean = {
+    val e = failure.cause
+
+    if (failure.phase == Committed) {
+      // The commit returned normally, so the batch is in the database whatever failed afterwards. Drop it rather
+      // than let a later attempt replay work that has already been applied.
+      batch.clear()
+      logAndThrowException(e)
+    }
+
+    if (options.transactionSettings.shouldFailOn(e)) {
+      log.error("unable to write batch due to explicitly configured failure condition", e)
+      throw e
+    }
+
+    // A streaming query being torn down interrupts the commit thread, which technically leaves the outcome unknown
+    // too. Spark replays the epoch either way, so there is nothing for the policy below to add here.
+    if (failure.phase == Committing && isConnectionFailure(e) && !isStoppedThread(e)) {
+      handleUnknownCommitOutcome(e)
+    } else {
+      retryOrThrow(e)
+    }
+  }
+
+  private def isStoppedThread(e: Throwable): Boolean =
+    e.isInstanceOf[ServiceUnavailableException] && e.getMessage == STOPPED_THREAD_EXCEPTION_MESSAGE
+
+  private def retryOrThrow(e: Throwable): Boolean = {
+    if (isRetryableException(e) && retries.getCount > 0) {
+      retries.countDown()
+      log.info(
+        s"encountered a transient exception while writing batch, retrying ${options.transactionSettings.retries - retries.getCount} time",
+        e
+      )
+      close()
+      LockSupport.parkNanos(Duration.ofMillis(options.transactionSettings.retryTimeout).toNanos)
+      true
+    } else {
+      logAndThrowException(e)
+    }
+  }
+
+  /**
+   * The connection dropped while the answer to `COMMIT` was in flight, so the server may or may not have applied
+   * the batch. Which of the two bad options to take is the user's call.
+   */
+  private def handleUnknownCommitOutcome(e: Throwable): Boolean = {
+    val context =
+      s"the outcome of the commit of a batch of ${batch.size()} elements is unknown " +
+        s"(jobId=$jobId, partitionId=$partitionId): the connection dropped before the server answered"
+
+    options.transactionSettings.unknownCommitOutcome match {
+      case UnknownCommitOutcome.RETRY =>
+        logWarning(
+          s"$context. Replaying the batch as configured by " +
+            s"'${Neo4jOptions.TRANSACTION_COMMIT_UNKNOWN_OUTCOME}=${UnknownCommitOutcome.RETRY}'. If the commit had " +
+            s"in fact been applied and this write is not idempotent, the batch is now duplicated. Use " +
+            s"'${Neo4jOptions.TRANSACTION_COMMIT_UNKNOWN_OUTCOME}=${UnknownCommitOutcome.FAIL}' to have the task " +
+            s"fail instead of replaying it.",
+          e
+        )
+        retryOrThrow(e)
+
+      case UnknownCommitOutcome.FAIL =>
+        close()
+        throw new Neo4jUnknownCommitOutcomeException(
+          s"$context. Failing the task without replaying the batch, as configured by " +
+            s"'${Neo4jOptions.TRANSACTION_COMMIT_UNKNOWN_OUTCOME}=${UnknownCommitOutcome.FAIL}'.",
+          e
+        )
+    }
+  }
+
+  private def logSkipped(): Unit = {
+    if (skipped > 0) {
+      log.info(s"Skipped $skipped rows that contained null values in one of their key property values.")
+      skipped = 0
     }
   }
 
@@ -166,8 +253,8 @@ abstract class BaseDataWriter(
    * exception that is thrown when the streaming query is interrupted, we don't want to cause
    * any error in this case. The transaction are rolled back automatically.
    */
-  private def logAndThrowException(e: Throwable): Unit = {
-    if (e.isInstanceOf[ServiceUnavailableException] && e.getMessage == STOPPED_THREAD_EXCEPTION_MESSAGE) {
+  private def logAndThrowException(e: Throwable): Nothing = {
+    if (isStoppedThread(e)) {
       logWarning(e.getMessage)
     } else {
       logError("unable to write batch", e)
@@ -199,4 +286,23 @@ abstract class BaseDataWriter(
   }
 
   override def currentMetricsValues(): Array[CustomTaskMetric] = metrics.metricValues()
+}
+
+private[spark] object BaseDataWriter {
+
+  /**
+   * How far an attempt at writing a batch got before it failed.
+   */
+  sealed private trait CommitPhase
+
+  /** The transaction had not been asked to commit, so the server cannot have applied it. */
+  private case object BeforeCommit extends CommitPhase
+
+  /** `COMMIT` had been sent but not answered, so whether the server applied it is unknown. */
+  private case object Committing extends CommitPhase
+
+  /** `COMMIT` was answered successfully, so the server definitely applied it. */
+  private case object Committed extends CommitPhase
+
+  private class BatchAttemptFailure(val phase: CommitPhase, val cause: Throwable) extends RuntimeException(cause)
 }

--- a/src/test/scala/org/neo4j/spark/util/Neo4jOptionsTest.scala
+++ b/src/test/scala/org/neo4j/spark/util/Neo4jOptionsTest.scala
@@ -220,6 +220,36 @@ class Neo4jOptionsTest {
   }
 
   @Test
+  def defaults_unknown_commit_outcome_to_retry(): Unit = {
+    val neo4jOptions = new Neo4jOptions(Map(Neo4jOptions.URL -> "neo4j://localhost"))
+
+    assertThat(neo4jOptions.transactionSettings.unknownCommitOutcome).isEqualTo(UnknownCommitOutcome.RETRY)
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = Array("FAIL", "fail", "Fail"))
+  def parses_unknown_commit_outcome_case_insensitively(value: String): Unit = {
+    val neo4jOptions = new Neo4jOptions(Map(
+      Neo4jOptions.URL -> "neo4j://localhost",
+      Neo4jOptions.TRANSACTION_COMMIT_UNKNOWN_OUTCOME -> value
+    ))
+
+    assertThat(neo4jOptions.transactionSettings.unknownCommitOutcome).isEqualTo(UnknownCommitOutcome.FAIL)
+  }
+
+  @Test
+  def rejects_an_unknown_commit_outcome_policy(): Unit = {
+    assertThatExceptionOfType(classOf[NoSuchElementException])
+      .isThrownBy(() =>
+        new Neo4jOptions(Map(
+          Neo4jOptions.URL -> "neo4j://localhost",
+          Neo4jOptions.TRANSACTION_COMMIT_UNKNOWN_OUTCOME -> "sometimes"
+        )).transactionSettings
+      )
+      .withMessage("No value found for 'sometimes'")
+  }
+
+  @Test
   def supports_transaction_timeout(): Unit = {
     val neo4jOptions = new Neo4jOptions(Map(
       Neo4jOptions.URL -> "neo4j://localhost,neo4j://foo.bar,neo4j://foo.bar.baz:7783",

--- a/src/test/scala/org/neo4j/spark/util/Neo4jUtilTest.scala
+++ b/src/test/scala/org/neo4j/spark/util/Neo4jUtilTest.scala
@@ -18,7 +18,14 @@ package org.neo4j.spark.util
 
 import org.apache.commons.lang3.StringUtils
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.neo4j.driver.exceptions.ClientException
+import org.neo4j.driver.exceptions.ConnectionReadTimeoutException
+import org.neo4j.driver.exceptions.ServiceUnavailableException
+import org.neo4j.driver.exceptions.SessionExpiredException
+import org.neo4j.driver.exceptions.TransientException
 
 class Neo4jUtilTest {
 
@@ -43,6 +50,41 @@ class Neo4jUtilTest {
     System.setProperty("neo4j.spark.platform", "abc")
     val actual = Neo4jUtil.connectorEnv
     assertEquals("abc", actual)
+  }
+
+  @Test
+  def testIsConnectionFailureForLostConnections(): Unit = {
+    assertTrue(Neo4jUtil.isConnectionFailure(new ServiceUnavailableException("connection terminated")))
+    assertTrue(Neo4jUtil.isConnectionFailure(new SessionExpiredException("server no longer available")))
+    assertTrue(Neo4jUtil.isConnectionFailure(ConnectionReadTimeoutException.INSTANCE))
+  }
+
+  @Test
+  def testIsConnectionFailureWalksTheCauseChain(): Unit = {
+    val wrapped = new RuntimeException("wrapper", new ServiceUnavailableException("connection terminated"))
+    assertTrue(Neo4jUtil.isConnectionFailure(wrapped))
+  }
+
+  @Test
+  def testIsConnectionFailureForAnswersFromTheServer(): Unit = {
+    assertFalse(Neo4jUtil.isConnectionFailure(null))
+    assertFalse(Neo4jUtil.isConnectionFailure(new ClientException(
+      "Neo.ClientError.Schema.ConstraintValidationFailed",
+      "already exists"
+    )))
+    // Retryable, but a definite answer: the server did not apply the transaction.
+    assertFalse(Neo4jUtil.isConnectionFailure(new TransientException(
+      "Neo.TransientError.Transaction.DeadlockDetected",
+      "deadlock"
+    )))
+  }
+
+  @Test
+  def testTransientExceptionsStayRetryable(): Unit = {
+    assertTrue(Neo4jUtil.isRetryableException(new TransientException(
+      "Neo.TransientError.Transaction.DeadlockDetected",
+      "deadlock"
+    )))
   }
 
 }

--- a/src/test/scala/org/neo4j/spark/writer/BaseDataWriterTest.scala
+++ b/src/test/scala/org/neo4j/spark/writer/BaseDataWriterTest.scala
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.spark.writer
+
+import org.apache.spark.sql.SaveMode
+import org.apache.spark.sql.types.StructType
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.MockedConstruction
+import org.mockito.Mockito.doThrow
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.mockConstruction
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.when
+import org.neo4j.caniuse.Neo4j
+import org.neo4j.caniuse.Neo4jDeploymentType.SELF_MANAGED
+import org.neo4j.caniuse.Neo4jEdition.ENTERPRISE
+import org.neo4j.caniuse.Neo4jVersion
+import org.neo4j.driver.Driver
+import org.neo4j.driver.Result
+import org.neo4j.driver.Session
+import org.neo4j.driver.SessionConfig
+import org.neo4j.driver.Transaction
+import org.neo4j.driver.TransactionConfig
+import org.neo4j.driver.Value
+import org.neo4j.driver.exceptions.ServiceUnavailableException
+import org.neo4j.driver.exceptions.TransientException
+import org.neo4j.driver.summary.ResultSummary
+import org.neo4j.driver.summary.SummaryCounters
+import org.neo4j.spark.util.DriverCache
+import org.neo4j.spark.util.Neo4jOptions
+import org.neo4j.spark.util.Neo4jUnknownCommitOutcomeException
+
+import java.util.Collections
+
+/**
+ * Covers how a failed batch is classified by the phase it failed in, which is what decides whether replaying it is
+ * safe. The driver is mocked so that a commit can be made to fail in ways that are impossible to provoke on demand
+ * against a real server.
+ */
+class BaseDataWriterTest {
+
+  private val neo4j = new Neo4j(new Neo4jVersion(5, 26, 0), ENTERPRISE, SELF_MANAGED, Collections.emptySet())
+
+  private val connectionLost = new ServiceUnavailableException("Connection to the database terminated")
+
+  private val deadlock =
+    new TransientException("Neo.TransientError.Transaction.DeadlockDetected", "deadlock detected")
+
+  @Test
+  def retriesABatchWhoseCommitOutcomeIsUnknownByDefault(): Unit = {
+    val fixture = new Fixture()
+    doThrow(connectionLost).when(fixture.transaction).commit()
+
+    assertThatExceptionOfType(classOf[ServiceUnavailableException])
+      .isThrownBy(() => fixture.writer(Map.empty).commit())
+
+    // The original attempt plus the whole retry budget, all of them replaying a batch that may already be there.
+    fixture.verifyDataQueriesRun(3)
+  }
+
+  @Test
+  def failsWithoutReplayingABatchWhoseCommitOutcomeIsUnknown(): Unit = {
+    val fixture = new Fixture()
+    doThrow(connectionLost).when(fixture.transaction).commit()
+
+    assertThatExceptionOfType(classOf[Neo4jUnknownCommitOutcomeException])
+      .isThrownBy(() => fixture.writer(Map(Neo4jOptions.TRANSACTION_COMMIT_UNKNOWN_OUTCOME -> "FAIL")).commit())
+      .withCauseInstanceOf(classOf[ServiceUnavailableException])
+
+    fixture.verifyDataQueriesRun(1)
+  }
+
+  @Test
+  def stillRetriesAConnectionLostBeforeTheCommitUnderFail(): Unit = {
+    val fixture = new Fixture()
+    doThrow(connectionLost).when(fixture.transaction).run(anyString(), any(classOf[Value]))
+
+    // The server never saw a COMMIT, so this batch is not in the database and replaying it is safe.
+    assertThatExceptionOfType(classOf[ServiceUnavailableException])
+      .isThrownBy(() => fixture.writer(Map(Neo4jOptions.TRANSACTION_COMMIT_UNKNOWN_OUTCOME -> "FAIL")).commit())
+
+    fixture.verifyDataQueriesRun(3)
+  }
+
+  @Test
+  def stillRetriesADeterminateCommitFailureUnderFail(): Unit = {
+    val fixture = new Fixture()
+    doThrow(deadlock).when(fixture.transaction).commit()
+
+    // The server answered the COMMIT with a failure, so it definitely did not apply the transaction.
+    assertThatExceptionOfType(classOf[TransientException])
+      .isThrownBy(() => fixture.writer(Map(Neo4jOptions.TRANSACTION_COMMIT_UNKNOWN_OUTCOME -> "FAIL")).commit())
+
+    fixture.verifyDataQueriesRun(3)
+  }
+
+  private class Fixture {
+    val driver: Driver = mock(classOf[Driver])
+    val session: Session = mock(classOf[Session])
+    val transaction: Transaction = mock(classOf[Transaction])
+
+    private val result = mock(classOf[Result])
+    private val summary = mock(classOf[ResultSummary])
+
+    when(driver.session(any(classOf[SessionConfig]))).thenReturn(session)
+    when(session.isOpen).thenReturn(true)
+    when(session.beginTransaction(any(classOf[TransactionConfig]))).thenReturn(transaction)
+    when(transaction.isOpen).thenReturn(true)
+    when(transaction.run(anyString(), any(classOf[Value]))).thenReturn(result)
+    when(result.consume()).thenReturn(summary)
+    when(summary.counters()).thenReturn(mock(classOf[SummaryCounters]))
+
+    /**
+     * Asserts how many times the batch was sent to the server, which is the number that says whether it was replayed.
+     */
+    def verifyDataQueriesRun(expected: Int): Unit = {
+      verify(transaction, times(expected)).run(anyString(), any(classOf[Value]))
+    }
+
+    /**
+     * Builds a writer whose [[DriverCache]] hands out the mocked driver. The construction mock stays open for the
+     * life of the fixture, which is the whole test.
+     */
+    def writer(extraOptions: Map[String, String]): Neo4jDataWriter = {
+      val construction: MockedConstruction[DriverCache] = mockConstruction(
+        classOf[DriverCache],
+        (cache: DriverCache, _: MockedConstruction.Context) => {
+          when(cache.getOrCreate()).thenReturn(driver)
+          ()
+        }
+      )
+      try {
+        val options = new Neo4jOptions(Map(
+          Neo4jOptions.URL -> "bolt://localhost:7687",
+          "labels" -> ":Person",
+          "access.mode" -> "Write",
+          Neo4jOptions.TRANSACTION_RETRIES -> "2"
+        ) ++ extraOptions)
+        new Neo4jDataWriter(
+          neo4j,
+          "job-1",
+          0,
+          new StructType(),
+          SaveMode.Append,
+          options,
+          Collections.emptyList()
+        )
+      } finally {
+        construction.close()
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces an option to decide if we can retry commits that failed in flight. The result of such commits is undefined and can result in duplicates. 